### PR TITLE
Feat 81 codeocean capsule

### DIFF
--- a/conf/ephys_upload_job_configs.yml
+++ b/conf/ephys_upload_job_configs.yml
@@ -15,8 +15,7 @@ jobs: # Select which jobs to run
   attach_metadata: true
   upload_to_s3: true
   upload_to_gcp: false
-  register_to_codeocean: true
-  trigger_codeocean_spike_sorting: true
+  trigger_codeocean_job: true
 data:
   name: openephys
 clip_data_job:
@@ -35,14 +34,11 @@ compress_data_job:
     disable_tqdm:
 upload_data_job:
   dryrun: false # Set this to true to perform a dryrun of the upload
-register_on_codeocean_job:
-  tags: ['ecephys', 'raw']
-  asset_name:  # Defaults to s3_prefix
-  mount:  # Defaults to s3_prefix
-trigger_codeocean_spike_sorting_job:
-  asset_id: # Will try to resolve it if the register_on_codeocean_job is run
-  mount:  # Defaults to s3_prefix
+trigger_codeocean_job:
   capsule_id:
+  job_type: # Defaults to data.name
+  bucket: # Defaults to endpoints.s3_bucket
+  prefix: # Defaults to endpoints.s3_prefix
 logging:
   level: "INFO" # Env variable LOG_LEVEL will override this value
   file: # If blank, will log to stdout.

--- a/src/aind_data_transfer/__init__.py
+++ b/src/aind_data_transfer/__init__.py
@@ -8,4 +8,4 @@ LOG_DATE_FMT = "%Y-%m-%d %H:%M"
 
 logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATE_FMT)
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/src/aind_data_transfer/configuration_loader.py
+++ b/src/aind_data_transfer/configuration_loader.py
@@ -91,16 +91,16 @@ class EphysJobConfigurationLoader:
             dest_data_folder = Path(configs["endpoints"]["dest_data_dir"]).name
             configs["endpoints"]["gcp_prefix"] = dest_data_folder
 
-        if configs["register_on_codeocean_job"]["asset_name"] is None:
-            configs["register_on_codeocean_job"]["asset_name"] = (
-                configs["endpoints"]["s3_prefix"])
+        if configs["trigger_codeocean_job"]["job_type"] is None:
+            configs["trigger_codeocean_job"]["job_type"] = (
+                configs["data"]["name"])
 
-        if configs["register_on_codeocean_job"]["mount"] is None:
-            configs["register_on_codeocean_job"]["mount"] = (
-                configs["endpoints"]["s3_prefix"])
+        if configs["trigger_codeocean_job"]["bucket"] is None:
+            configs["trigger_codeocean_job"]["bucket"] = (
+                configs["endpoints"]["s3_bucket"])
 
-        if configs["trigger_codeocean_spike_sorting_job"]["mount"] is None:
-            configs["trigger_codeocean_spike_sorting_job"]["mount"] = (
+        if configs["trigger_codeocean_job"]["prefix"] is None:
+            configs["trigger_codeocean_job"]["prefix"] = (
                 configs["endpoints"]["s3_prefix"])
 
     @staticmethod

--- a/src/aind_data_transfer/jobs/openephys_job.py
+++ b/src/aind_data_transfer/jobs/openephys_job.py
@@ -182,11 +182,15 @@ if __name__ == "__main__":  # noqa: C901
         logging.info("Finished uploading to gcp.")
 
     if job_configs["jobs"]["trigger_codeocean_job"]:
+        logging.info("Triggering capsule run.")
         capsule_id = job_configs["trigger_codeocean_job"]["capsule_id"]
         co_api_token = os.getenv("CODEOCEAN_API_TOKEN")
         co_domain = job_configs["endpoints"]["codeocean_domain"]
         co_client = CodeOceanClient(domain=co_domain,
                                     token=co_api_token)
-        co_client.run_capsule(capsule_id=capsule_id,
-                              data_assets=[],
-                              parameters=[json.dumps(job_configs)])
+        run_response = co_client.run_capsule(
+            capsule_id=capsule_id,
+            data_assets=[],
+            parameters=[json.dumps(job_configs)]
+        )
+        logging.debug(f"Run response: {run_response.json()}")

--- a/src/aind_data_transfer/jobs/openephys_job.py
+++ b/src/aind_data_transfer/jobs/openephys_job.py
@@ -7,8 +7,7 @@ import platform
 from datetime import datetime, timezone
 from pathlib import Path
 import warnings
-
-from botocore.session import get_session
+import json
 
 from aind_data_transfer.codeocean import CodeOceanClient
 from aind_data_transfer.configuration_loader import EphysJobConfigurationLoader
@@ -182,58 +181,12 @@ if __name__ == "__main__":  # noqa: C901
             )
         logging.info("Finished uploading to gcp.")
 
-    # TODO: Combine these steps into a capsule?
-    # Register Asset on CodeOcean
-    if (job_configs["jobs"]["register_to_codeocean"] or
-            job_configs["jobs"]["trigger_codeocean_spike_sorting"]):
-        data_asset_response = None
+    if job_configs["jobs"]["trigger_codeocean_job"]:
+        capsule_id = job_configs["trigger_codeocean_job"]["capsule_id"]
         co_api_token = os.getenv("CODEOCEAN_API_TOKEN")
         co_domain = job_configs["endpoints"]["codeocean_domain"]
         co_client = CodeOceanClient(domain=co_domain,
                                     token=co_api_token)
-        if job_configs["jobs"]["register_to_codeocean"]:
-            # Use botocore to retrieve aws access tokens
-            logging.info("Registering data asset to code ocean.")
-            aws_session = get_session()
-            aws_credentials = aws_session.get_credentials()
-            aws_key = aws_credentials.access_key
-            aws_secret = aws_credentials.secret_key
-            co_tags = job_configs["register_on_codeocean_job"]["tags"]
-            asset_name = job_configs["register_on_codeocean_job"]["asset_name"]
-            mount = job_configs["register_on_codeocean_job"]["mount"]
-            bucket = job_configs["endpoints"]["s3_bucket"]
-            prefix = job_configs["endpoints"]["s3_prefix"]
-            data_asset_response = co_client.register_data_asset(
-                asset_name=asset_name,
-                mount=mount,
-                bucket=bucket,
-                prefix=prefix,
-                access_key_id=aws_key,
-                secret_access_key=aws_secret,
-                tags=co_tags,
-            )
-            logging.info(f"Finished registering data asset to code ocean. "
-                         f"{data_asset_response.json()}")
-
-        # Automatically trigger capsule run
-        if job_configs["jobs"]["trigger_codeocean_spike_sorting"]:
-            logging.info("Triggering a capsule run.")
-            conf_name = "trigger_codeocean_spike_sorting_job"
-            if data_asset_response is not None:
-                response_contents = data_asset_response.json()
-                data_asset_id = response_contents["id"]
-            else:
-                data_asset_id = (
-                    job_configs[conf_name]["asset_id"])
-            capsule_id = (
-                job_configs[conf_name]["capsule_id"])
-            mount = (
-                job_configs[conf_name]["mount"])
-            data_assets = [{"id": data_asset_id, "mount": mount}]
-            capsule_run_response = (
-                co_client.run_capsule(capsule_id=capsule_id,
-                                      data_assets=data_assets))
-
-            logging.info(f"Finished triggering a capsule run. Please check "
-                         f"CodeOcean for status of capsule. "
-                         f"{capsule_run_response}")
+        co_client.run_capsule(capsule_id=capsule_id,
+                              data_assets=[],
+                              parameters=[json.dumps(job_configs)])

--- a/tests/resources/test_configs/ephys_upload_job_test_configs.yml
+++ b/tests/resources/test_configs/ephys_upload_job_test_configs.yml
@@ -15,8 +15,7 @@ jobs: # Select which jobs to run
   attach_metadata: true
   upload_to_s3: true
   upload_to_gcp: true
-  register_to_codeocean: false
-  trigger_codeocean_spike_sorting: false
+  trigger_codeocean_job: false
 data:
   name: openephys
 clip_data_job:
@@ -35,14 +34,11 @@ compress_data_job:
     disable_tqdm:
 upload_data_job:
   dryrun: true # Set this to true to perform a dryrun of the upload
-register_on_codeocean_job:
-  tags: ['ecephys', 'raw']
-  asset_name:  # Defaults to s3_prefix
-  mount:  # Defaults to s3_prefix
-trigger_codeocean_spike_sorting_job:
-  asset_id: # Will try to resolve it if the register_on_codeocean_job is run
-  mount:  # Defaults to s3_prefix
+trigger_codeocean_job:
   capsule_id:
+  job_type: # Defaults to data.name
+  bucket: # Defaults to endpoints.s3_bucket
+  prefix: # Defaults to endpoints.s3_prefix
 logging:
-  level: "INFO" # Will override with env variable LOG_LEVEL
-  file:  # If blank, will log to stdout.
+  level: "INFO" # Env variable LOG_LEVEL will override this value
+  file: # If blank, will log to stdout.

--- a/tests/resources/test_configs/example_configs_src_pattern1.yml
+++ b/tests/resources/test_configs/example_configs_src_pattern1.yml
@@ -15,8 +15,7 @@ jobs: # Select which jobs to run
   attach_metadata: true
   upload_to_s3: true
   upload_to_gcp: true
-  register_to_codeocean: false
-  trigger_codeocean_spike_sorting: false
+  trigger_codeocean_job: false
 data:
   name: openephys
 clip_data_job:
@@ -35,14 +34,11 @@ compress_data_job:
     disable_tqdm:
 upload_data_job:
   dryrun: true # Set this to true to perform a dryrun of the upload
-register_on_codeocean_job:
-  tags: ['ecephys']
-  asset_name:  # Defaults to s3_prefix
-  mount:  # Defaults to s3_prefix
-trigger_codeocean_spike_sorting_job:
-  asset_id: # Will try to resolve it if the register_on_codeocean_job is run
-  mount:  # Defaults to s3_prefix
+trigger_codeocean_job:
   capsule_id:
+  job_type: # Defaults to data.name
+  bucket: # Defaults to endpoints.s3_bucket
+  prefix: # Defaults to endpoints.s3_prefix
 logging:
   level: "INFO" # Will override with env variable LOG_LEVEL
   file: # If blank, will log to stdout.

--- a/tests/resources/test_configs/example_configs_src_pattern2.yml
+++ b/tests/resources/test_configs/example_configs_src_pattern2.yml
@@ -15,8 +15,7 @@ jobs: # Select which jobs to run
   attach_metadata: true
   upload_to_s3: true
   upload_to_gcp: true
-  register_to_codeocean: false
-  trigger_codeocean_spike_sorting: false
+  trigger_codeocean_job: false
 data:
   name: openephys
 clip_data_job:
@@ -35,14 +34,11 @@ compress_data_job:
     disable_tqdm:
 upload_data_job:
   dryrun: true # Set this to true to perform a dryrun of the upload
-register_on_codeocean_job:
-  tags: ['ecephys']
-  asset_name:  # Defaults to s3_prefix
-  mount:  # Defaults to s3_prefix
-trigger_codeocean_spike_sorting_job:
-  asset_id: # Will try to resolve it if the register_on_codeocean_job is run
-  mount:  # Defaults to s3_prefix
+trigger_codeocean_job:
   capsule_id:
+  job_type: # Defaults to data.name
+  bucket: # Defaults to endpoints.s3_bucket
+  prefix: # Defaults to endpoints.s3_prefix
 logging:
   level: "INFO" # Will override with env variable LOG_LEVEL
   file: # If blank, will log to stdout.

--- a/tests/resources/test_metadata/processing.json
+++ b/tests/resources/test_metadata/processing.json
@@ -17,8 +17,7 @@
                     "compress": true,
                     "upload_to_s3": true,
                     "upload_to_gcp": true,
-                    "register_to_codeocean": false,
-                    "trigger_codeocean_spike_sorting": false
+                    "trigger_codeocean_job": false
                 },
                 "endpoints": {
                     "raw_data_dir": "tests/resources/v0.6.x_neuropixels_multiexp_multistream",
@@ -57,15 +56,11 @@
                 "upload_data_job": {
                     "dryrun": true
                 },
-                "register_on_codeocean_job": {
-                    "tags": [
-                        "ecephys",
-                        "raw"
-                    ],
-                    "asset_name": "v0.6.x_neuropixels_multiexp_multistream",
-                    "mount": "v0.6.x_neuropixels_multiexp_multistream"
+                "trigger_codeocean_job": {
+                    "job_type": "openephys",
+                    "bucket": "aind-transfer-test",
+                    "prefix": "v0.6.x_neuropixels_multiexp_multistream"
                 },
-                "trigger_codeocean_spike_sorting_job": {"mount": "v0.6.x_neuropixels_multiexp_multistream"},
                 "logging": {"level": "INFO"}
             }
         }

--- a/tests/test_configuration_loader.py
+++ b/tests/test_configuration_loader.py
@@ -37,8 +37,7 @@ class TestEphysJobConfigs(unittest.TestCase):
                 "attach_metadata": True,
                 "upload_to_s3": True,
                 "upload_to_gcp": True,
-                "register_to_codeocean": False,
-                "trigger_codeocean_spike_sorting": False
+                "trigger_codeocean_job": False
             },
             "endpoints": {
                 "raw_data_dir": raw_data_dir,
@@ -67,12 +66,11 @@ class TestEphysJobConfigs(unittest.TestCase):
                 "scale_params": {"chunk_size": 20},
             },
             "upload_data_job": {"dryrun": True},
-            "register_on_codeocean_job": {
-                "tags": ["ecephys", "raw"],
-                "asset_name": "v0.6.x_neuropixels_multiexp_multistream",
-                "mount": "v0.6.x_neuropixels_multiexp_multistream",
+            "trigger_codeocean_job": {
+                "job_type": "openephys",
+                "bucket": "aind-transfer-test",
+                "prefix": "v0.6.x_neuropixels_multiexp_multistream",
             },
-            "trigger_codeocean_spike_sorting_job": {"mount": "v0.6.x_neuropixels_multiexp_multistream"},
             "logging": {"level": "INFO"}
         }
         conf_file_path = CONFIGS_DIR / "ephys_upload_job_test_configs.yml"
@@ -93,8 +91,7 @@ class TestEphysJobConfigs(unittest.TestCase):
                 "attach_metadata": True,
                 "upload_to_s3": True,
                 "upload_to_gcp": True,
-                "register_to_codeocean": False,
-                "trigger_codeocean_spike_sorting": False
+                "trigger_codeocean_job": False
             },
             "endpoints": {
                 "raw_data_dir": raw_data_dir,
@@ -123,12 +120,11 @@ class TestEphysJobConfigs(unittest.TestCase):
                 "scale_params": {},
             },
             "upload_data_job": {"dryrun": True},
-            "register_on_codeocean_job": {
-                "tags": ["ecephys"],
-                "asset_name": "ecephys_625463_2022-10-06_10-14-25",
-                "mount": "ecephys_625463_2022-10-06_10-14-25",
+            "trigger_codeocean_job": {
+                "job_type": "openephys",
+                "bucket": "aind-ephys-data",
+                "prefix": "ecephys_625463_2022-10-06_10-14-25",
             },
-            "trigger_codeocean_spike_sorting_job": {"mount": "ecephys_625463_2022-10-06_10-14-25"},
             "logging": {"level": "INFO"}
         }
 


### PR DESCRIPTION
Closes #81
Things to do down the road:
- Store the openehpys job configs as a pydantic model and serialize it to json and send as a parameter to the code ocean trigger capsule. Deserialize back into the pydantic in the code ocean trigger capsule.