### PR TITLE
fix: refactors config loaders

### DIFF
--- a/src/aind_data_transfer/__init__.py
+++ b/src/aind_data_transfer/__init__.py
@@ -8,4 +8,4 @@ LOG_DATE_FMT = "%Y-%m-%d %H:%M"
 
 logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATE_FMT)
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/src/aind_data_transfer/config_loader/configuration_loader.py
+++ b/src/aind_data_transfer/config_loader/configuration_loader.py
@@ -1,0 +1,79 @@
+"""Loads Imaging job configurations"""
+import argparse
+from pathlib import Path
+
+import yaml
+from numcodecs import Blosc
+
+from aind_data_transfer.util.file_utils import is_cloud_url, parse_cloud_url
+
+
+class ImagingJobConfigurationLoader:
+
+    def load_configs(self, sys_args):
+        """Load yaml config at conf_src Path as python dict"""
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-c", "--conf-file-location", required=True, type=str
+        )
+        parser.add_argument(
+            "-r", "--raw-data-source", required=False, type=str
+        )
+        args = parser.parse_args(sys_args)
+        conf_src = args.conf_file_location
+        with open(conf_src) as f:
+            config = yaml.load(f, Loader=yaml.SafeLoader)
+        if args.raw_data_source is not None:
+            config["endpoints"]["raw_data_dir"] = args.raw_data_source
+        self.__resolve_endpoints(config)
+        self.__parse_compressor_configs(config)
+        return config
+
+    @staticmethod
+    def __resolve_endpoints(configs):
+        """
+        If the destination folder is a cloud bucket without prefix, a prefix will be
+        created using the acquisition directory name.
+        Args:
+            configs (dic): Configurations
+
+        Returns:
+            None, modifies the base configs in place
+        """
+
+        dest_data_dir = configs["endpoints"]["dest_data_dir"]
+        if is_cloud_url(dest_data_dir):
+            provider, bucket, prefix = parse_cloud_url(dest_data_dir)
+            if prefix == "":
+                prefix = Path(configs["endpoints"]["raw_data_dir"]).name
+                dest_data_dir = dest_data_dir.strip("/") + '/' + prefix
+                configs["endpoints"]["dest_data_dir"] = dest_data_dir
+
+    @staticmethod
+    def __parse_compressor_configs(configs):
+        """Util method to map a string to class attribute"""
+        try:
+            compressor_name = configs["transcode_job"]["compressor"][
+                "compressor_name"
+            ]
+        except KeyError:
+            compressor_name = None
+        try:
+            compressor_kwargs = configs["transcode_job"]["compressor"][
+                "kwargs"
+            ]
+        except KeyError:
+            compressor_kwargs = None
+        if (
+            compressor_name
+            and compressor_name == Blosc.codec_id
+            and compressor_kwargs
+            and "shuffle" in compressor_kwargs
+        ):
+            shuffle_str = configs["transcode_job"]["compressor"]["kwargs"][
+                "shuffle"
+            ]
+            shuffle_val = getattr(Blosc, shuffle_str)
+            configs["transcode_job"]["compressor"]["kwargs"][
+                "shuffle"
+            ] = shuffle_val

--- a/src/aind_data_transfer/config_loader/ephys_configuration_loader.py
+++ b/src/aind_data_transfer/config_loader/ephys_configuration_loader.py
@@ -1,4 +1,4 @@
-"""Loads job configurations"""
+"""Loads Ephys job configurations"""
 import argparse
 import os
 import re
@@ -8,7 +8,6 @@ import yaml
 from numcodecs import Blosc
 
 from aind_data_transfer.readers import EphysReaders
-from aind_data_transfer.util.file_utils import is_cloud_url, parse_cloud_url
 
 
 class EphysJobConfigurationLoader:
@@ -142,74 +141,3 @@ class EphysJobConfigurationLoader:
         config_without_nones = self.__remove_none(raw_config)
         self.__parse_compressor_configs(config_without_nones)
         return config_without_nones
-
-
-class ImagingJobConfigurationLoader:
-
-    def load_configs(self, sys_args):
-        """Load yaml config at conf_src Path as python dict"""
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "-c", "--conf-file-location", required=True, type=str
-        )
-        parser.add_argument(
-            "-r", "--raw-data-source", required=False, type=str
-        )
-        args = parser.parse_args(sys_args)
-        conf_src = args.conf_file_location
-        with open(conf_src) as f:
-            config = yaml.load(f, Loader=yaml.SafeLoader)
-        if args.raw_data_source is not None:
-            config["endpoints"]["raw_data_dir"] = args.raw_data_source
-        self.__resolve_endpoints(config)
-        self.__parse_compressor_configs(config)
-        return config
-
-    @staticmethod
-    def __resolve_endpoints(configs):
-        """
-        If the destination folder is a cloud bucket without prefix, a prefix will be
-        created using the acquisition directory name.
-        Args:
-            configs (dic): Configurations
-
-        Returns:
-            None, modifies the base configs in place
-        """
-
-        dest_data_dir = configs["endpoints"]["dest_data_dir"]
-        if is_cloud_url(dest_data_dir):
-            provider, bucket, prefix = parse_cloud_url(dest_data_dir)
-            if prefix == "":
-                prefix = Path(configs["endpoints"]["raw_data_dir"]).name
-                dest_data_dir = dest_data_dir.strip("/") + '/' + prefix
-                configs["endpoints"]["dest_data_dir"] = dest_data_dir
-
-    @staticmethod
-    def __parse_compressor_configs(configs):
-        """Util method to map a string to class attribute"""
-        try:
-            compressor_name = configs["transcode_job"]["compressor"][
-                "compressor_name"
-            ]
-        except KeyError:
-            compressor_name = None
-        try:
-            compressor_kwargs = configs["transcode_job"]["compressor"][
-                "kwargs"
-            ]
-        except KeyError:
-            compressor_kwargs = None
-        if (
-            compressor_name
-            and compressor_name == Blosc.codec_id
-            and compressor_kwargs
-            and "shuffle" in compressor_kwargs
-        ):
-            shuffle_str = configs["transcode_job"]["compressor"]["kwargs"][
-                "shuffle"
-            ]
-            shuffle_val = getattr(Blosc, shuffle_str)
-            configs["transcode_job"]["compressor"]["kwargs"][
-                "shuffle"
-            ] = shuffle_val

--- a/src/aind_data_transfer/jobs/openephys_job.py
+++ b/src/aind_data_transfer/jobs/openephys_job.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 from aind_codeocean_api.codeocean import CodeOceanClient
 
-from aind_data_transfer.configuration_loader import EphysJobConfigurationLoader
+from aind_data_transfer.config_loader.ephys_configuration_loader import (
+    EphysJobConfigurationLoader,
+)
 from aind_data_transfer.readers import EphysReaders
 from aind_data_transfer.transformations.compressors import EphysCompressors
 from aind_data_transfer.transformations.metadata_creation import (

--- a/src/aind_data_transfer/jobs/transcode_job.py
+++ b/src/aind_data_transfer/jobs/transcode_job.py
@@ -8,8 +8,9 @@ from shutil import copytree, ignore_patterns
 
 from numcodecs import Blosc
 
-from aind_data_transfer.configuration_loader import \
-    ImagingJobConfigurationLoader
+from aind_data_transfer.config_loader.configuration_loader import (
+    ImagingJobConfigurationLoader,
+)
 from aind_data_transfer.readers import ImagingReaders
 from aind_data_transfer.util.file_utils import is_cloud_url, parse_cloud_url
 

--- a/tests/test_configuration_loader.py
+++ b/tests/test_configuration_loader.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 from numcodecs import Blosc
 
-from aind_data_transfer.configuration_loader import (
-    EphysJobConfigurationLoader,
+from aind_data_transfer.config_loader.configuration_loader import (
     ImagingJobConfigurationLoader,
 )
+from aind_data_transfer.config_loader.ephys_configuration_loader import \
+    EphysJobConfigurationLoader
 
 TEST_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 CONFIGS_DIR = TEST_DIR / "resources" / "test_configs"

--- a/tests/test_configuration_loader.py
+++ b/tests/test_configuration_loader.py
@@ -8,8 +8,9 @@ from numcodecs import Blosc
 from aind_data_transfer.config_loader.configuration_loader import (
     ImagingJobConfigurationLoader,
 )
-from aind_data_transfer.config_loader.ephys_configuration_loader import \
-    EphysJobConfigurationLoader
+from aind_data_transfer.config_loader.ephys_configuration_loader import (
+    EphysJobConfigurationLoader,
+)
 
 TEST_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 CONFIGS_DIR = TEST_DIR / "resources" / "test_configs"

--- a/tests/test_metadata_creation.py
+++ b/tests/test_metadata_creation.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 from aind_data_schema import Processing
 
-from aind_data_transfer.configuration_loader import EphysJobConfigurationLoader
+from aind_data_transfer.config_loader.ephys_configuration_loader import \
+    EphysJobConfigurationLoader
 from aind_data_transfer.transformations.metadata_creation import (
     ProcessingMetadata,
 )

--- a/tests/test_metadata_creation.py
+++ b/tests/test_metadata_creation.py
@@ -8,8 +8,9 @@ from pathlib import Path
 
 from aind_data_schema import Processing
 
-from aind_data_transfer.config_loader.ephys_configuration_loader import \
-    EphysJobConfigurationLoader
+from aind_data_transfer.config_loader.ephys_configuration_loader import (
+    EphysJobConfigurationLoader,
+)
 from aind_data_transfer.transformations.metadata_creation import (
     ProcessingMetadata,
 )


### PR DESCRIPTION
Closes #95 

- We may want to keep the imaging and ephys classes in separate modules so we can do `pip install aind-data-transfer[ephys]` and `pip install aind-data-transfer[imaging]`