### PR TITLE
Refactor 97 add config

### DIFF
--- a/conf/ephys_upload_job_configs.yml
+++ b/conf/ephys_upload_job_configs.yml
@@ -35,6 +35,7 @@ compress_data_job:
     num_chunks_per_segment:
     chunk_size:
     disable_tqdm:
+  max_windows_filename_len: # Windows OS has max filename length of 256, which can mess up zarr writer
 upload_data_job:
   dryrun: false # Set this to true to perform a dryrun of the upload
 trigger_codeocean_job:

--- a/src/aind_data_transfer/__init__.py
+++ b/src/aind_data_transfer/__init__.py
@@ -8,4 +8,4 @@ LOG_DATE_FMT = "%Y-%m-%d %H:%M"
 
 logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATE_FMT)
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/src/aind_data_transfer/jobs/openephys_job.py
+++ b/src/aind_data_transfer/jobs/openephys_job.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":  # noqa: C901
         aws_secret_names = job_configs["aws_secret_names"]
         secret_name = aws_secret_names.get("video_encryption_password")
         secret_region = aws_secret_names.get("region")
-        video_encryption_key_val = None
+        video_encryption_key_val = {"password": None}
         if secret_name:
             video_encryption_key_val = json.loads(
                 get_secret(secret_name, secret_region)

--- a/src/aind_data_transfer/jobs/openephys_job.py
+++ b/src/aind_data_transfer/jobs/openephys_job.py
@@ -53,10 +53,6 @@ if __name__ == "__main__":  # noqa: C901
     data_src_dir = Path(job_configs["endpoints"]["raw_data_dir"])
     dest_data_dir = Path(job_configs["endpoints"]["dest_data_dir"])
 
-    # Correct NP-opto electrode positions:
-    # correction is skipped if Neuropix-PXI version > 0.4.0
-    correct_np_opto_electrode_locations(data_src_dir)
-
     logging.info("Finished loading configs.")
 
     # Clip data job
@@ -83,6 +79,11 @@ if __name__ == "__main__":  # noqa: C901
             video_encryption_key_val["password"],
             **clip_kwargs,
         )
+
+        # Correct NP-opto electrode positions:
+        # correction is skipped if Neuropix-PXI version > 0.4.0
+        correct_np_opto_electrode_locations(clipped_data_path)
+
         logging.info("Finished clipping source data.")
 
     # Compress data job
@@ -98,6 +99,9 @@ if __name__ == "__main__":  # noqa: C901
         format_kwargs = job_configs["compress_data_job"]["format_kwargs"]
         scale_kwargs = job_configs["compress_data_job"]["scale_params"]
         write_kwargs = job_configs["compress_data_job"]["write_kwargs"]
+        max_filename_length = (
+            job_configs["compress_data_job"].get("max_windows_filename_len")
+        )
         read_blocks = EphysReaders.get_read_blocks(data_name, data_src_dir)
         compressor = EphysCompressors.get_compressor(
             compressor_name, **compressor_kwargs
@@ -109,6 +113,7 @@ if __name__ == "__main__":  # noqa: C901
             read_blocks=scaled_read_blocks,
             compressor=compressor,
             output_dir=compressed_data_path,
+            max_windows_filename_len=max_filename_length,
             job_kwargs=write_kwargs,
             **format_kwargs,
         )

--- a/tests/resources/test_configs/ephys_upload_job_test_configs.yml
+++ b/tests/resources/test_configs/ephys_upload_job_test_configs.yml
@@ -35,6 +35,7 @@ compress_data_job:
     num_chunks_per_segment:
     chunk_size: 20
     disable_tqdm:
+  max_windows_filename_len:
 upload_data_job:
   dryrun: true # Set this to true to perform a dryrun of the upload
 trigger_codeocean_job:

--- a/tests/resources/test_configs/ephys_upload_job_test_configs.yml
+++ b/tests/resources/test_configs/ephys_upload_job_test_configs.yml
@@ -10,7 +10,7 @@ endpoints:
   code_repo_location: https://location_of_code_repo
 aws_secret_names:
   region: us-west-2
-  video_encryption_password: "secret_name_for_vid_password"
+  video_encryption_password:
   code_ocean_api_token_name: "secret_name_for_api_token"
 jobs: # Select which jobs to run
   clip: true

--- a/tests/resources/test_configs/example_configs_src_pattern1.yml
+++ b/tests/resources/test_configs/example_configs_src_pattern1.yml
@@ -35,6 +35,7 @@ compress_data_job:
     num_chunks_per_segment:
     chunk_size:
     disable_tqdm:
+  max_windows_filename_len:
 upload_data_job:
   dryrun: true # Set this to true to perform a dryrun of the upload
 trigger_codeocean_job:

--- a/tests/resources/test_configs/example_configs_src_pattern2.yml
+++ b/tests/resources/test_configs/example_configs_src_pattern2.yml
@@ -35,6 +35,7 @@ compress_data_job:
     num_chunks_per_segment:
     chunk_size:
     disable_tqdm:
+  max_windows_filename_len:
 upload_data_job:
   dryrun: true # Set this to true to perform a dryrun of the upload
 trigger_codeocean_job:

--- a/tests/resources/test_metadata/processing.json
+++ b/tests/resources/test_metadata/processing.json
@@ -31,8 +31,7 @@
                 },
                 "aws_secret_names": {
                     "code_ocean_api_token_name": "secret_name_for_api_token",
-                    "region": "us-west-2",
-                    "video_encryption_password": "secret_name_for_vid_password"},
+                    "region": "us-west-2"},
                 "data": {
                     "name": "openephys"
                 },

--- a/tests/test_configuration_loader.py
+++ b/tests/test_configuration_loader.py
@@ -50,8 +50,7 @@ class TestEphysJobConfigs(unittest.TestCase):
             },
             "aws_secret_names": {
                 "code_ocean_api_token_name": "secret_name_for_api_token",
-                "region": "us-west-2",
-                "video_encryption_password": "secret_name_for_vid_password",
+                "region": "us-west-2"
             },
             "data": {"name": "openephys"},
             "clip_data_job": {


### PR DESCRIPTION
Closes #97
Closes #87

- Makes MAX_WINDOWS_FILENAME_LENGTH configurable
- Leaves raw data pristine, and fixes settings.xml file in clipped folder only
- Fixes an issue with the video_encryption key in the test resources