### PR TITLE
Feat 126 generic job

### DIFF
--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -1,5 +1,5 @@
 from aind_data_transfer.transformations.metadata_creation import (
-    ProcessingMetadata,
+    DataDescriptionMetadata,
     SubjectMetadata,
 )
 
@@ -7,75 +7,133 @@ import logging
 import json
 import sys
 import argparse
+import datetime
+import tempfile
+import os
+from aind_codeocean_api.codeocean import CodeOceanClient
+from aind_data_transfer.util.s3_utils import upload_to_s3, get_secret
 
 
-class GenericUploadJob:
+class GenericS3UploadJob:
 
-    @staticmethod
-    def attach_subject_info(subject_id,
-                            metadata_url,
-                            dest_data_dir) -> None:
-        """Writes subject metadata a destination directory"""
-        # Subject metadata
-        logging.info("Creating subject.json file.")
-        subject_instance = SubjectMetadata.ephys_job_to_subject(
-            metadata_url, subject_id, dest_data_dir.name
+    upload_endpoints_keys = {"upload_endpoints": ["metadata_service_url",
+                                                  "codeocean_domain",
+                                                  "codeocean_trigger_capsule"]}
+
+    def run_job(self,
+                args: dict,
+                dryrun: bool = False,
+                s3_region="us-west-2") -> None:
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-r", "--raw-data-source", required=True, type=str
         )
-        s_file_path = dest_data_dir / SubjectMetadata.output_file_name
-        if subject_instance is not None:
-            with open(s_file_path, "w") as f:
-                f.write(json.dumps(subject_instance, indent=4))
-            logging.info("Finished creating subject.json file.")
-        else:
-            logging.warning("No subject.json file created!")
-
-    @staticmethod
-    def attach_processing_info(dest_data_dir,
-                               start_date_time,
-                               end_date_time,
-                               input_location,
-                               output_location,
-                               code_url,
-                               parameters) -> None:
-        """Writes processing metadata a destination directory"""
-
-        # Processing metadata
-        logging.info("Creating processing.json file.")
-        processing_instance = ProcessingMetadata.ephys_job_to_processing(
-            start_date_time=start_date_time,
-            end_date_time=end_date_time,
-            input_location=str(input_location),
-            output_location=output_location,
-            code_url=code_url,
-            parameters=parameters,
-            notes=None,
+        parser.add_argument(
+            "-b", "--s3-bucket", required=True, type=str
+        )
+        parser.add_argument(
+            "-s", "--subject-id", required=True, type=str
+        )
+        parser.add_argument(
+            "-m", "--modality", required=True, type=str
+        )
+        parser.add_argument(
+            "-d", "--acq-date", required=True, type=str
+        )
+        parser.add_argument(
+            "-t", "--acq-time", required=True, type=str
+        )
+        parser.add_argument(
+            "-e", "--endpoints", required=False, type=str
         )
 
-        file_path = dest_data_dir / ProcessingMetadata.output_file_name
-        with open(file_path, "w") as f:
-            contents = processing_instance.json(**{"indent": 4})
-            f.write(contents)
-        logging.info("Finished creating processing.json file.")
+        job_args = parser.parse_args(args)
+
+        s3_prefix = self.create_s3_prefix(job_args.modality,
+                                          job_args.subject_id,
+                                          job_args.acq_date,
+                                          job_args.acq_time)
+        data_prefix = "/".join([s3_prefix, job_args.modality])
+
+        upload_to_s3(directory_to_upload=job_args.raw_data_soucre,
+                     s3_bucket=job_args.s3_bucket,
+                     s3_prefix=data_prefix,
+                     dryrun=dryrun)
+
+        endpoints = job_args.get("endpoints")
+        if not endpoints:
+            s3_secret_name = list(self.upload_endpoints_keys.keys())[0]
+            get_secret(s3_secret_name, s3_region)
+            endpoints = json.loads(get_secret(s3_secret_name, s3_region))
+
+        # Create subject.json file if metadata service url is provided
+        metadata_service_url = endpoints.get("metadata_service_url")
+        if metadata_service_url:
+            subject_metadata = (
+                SubjectMetadata.ephys_job_to_subject(
+                    metadata_service_url=metadata_service_url,
+                    subject_id=job_args.subect_id)
+            )
+            subject_s3_prefix = SubjectMetadata.output_file_name
+            with tempfile.NamedTemporaryFile() as tmp:
+                tmp.write(json.dumps(subject_metadata, indent=4))
+                upload_to_s3(directory_to_upload=tmp.name,
+                             s3_bucket=job_args.s3_bucket,
+                             s3_prefix=subject_s3_prefix,
+                             dryrun=dryrun)
+
+        # Create data description file
+        data_description_metadata = (
+            DataDescriptionMetadata.get_data_description(name=s3_prefix)
+        )
+        with tempfile.NamedTemporaryFile() as tmp:
+            json_contents = data_description_metadata.json(indent=4)
+            tmp.write(json_contents)
+            data_desc_s3_prefix = DataDescriptionMetadata.output_file_name
+            upload_to_s3(directory_to_upload=tmp.name,
+                         s3_bucket=job_args.s3_bucket,
+                         s3_prefix=data_desc_s3_prefix,
+                         dryrun=dryrun)
+
+        # Register to code ocean if url is provided
+        codeocean_url = endpoints.get("codeocean_url")
+        if codeocean_url:
+            logging.info("Triggering capsule run.")
+            capsule_id = endpoints.get("codeocean_trigger_capsule")
+            co_api_token = os.getenv("CODEOCEAN_API_TOKEN")
+            if co_api_token is None:
+                token_key_val = json.loads(
+                    get_secret("codeocean-api-token", "us-west-2"))
+                co_api_token = token_key_val["CODEOCEAN_READWRITE_TOKEN"]
+            co_domain = endpoints.get("codeocean_domain")
+            co_client = CodeOceanClient(domain=co_domain, token=co_api_token)
+            run_response = co_client.run_capsule(
+                capsule_id=capsule_id,
+                data_assets=[],
+                parameters=[],
+            )
+            logging.debug(f"Run response: {run_response.json()}")
+
+    @staticmethod
+    def create_s3_prefix(modality: str,
+                         subject_id: str,
+                         acq_date: str,
+                         acq_time: str) -> str:
+        # Validate date and time strings
+        try:
+            datetime.datetime.strptime(acq_date + " " + acq_time,
+                                       '%Y-%m-%d %H-%M-%S')
+        except ValueError:
+            raise ValueError("Incorrect data format, acq_date should be "
+                             "yyyy-MM-dd and acq_time should be HH-mm-SS")
+
+        return "_".join([modality, subject_id, acq_date, acq_time])
 
 
-def run_job(args):
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-r", "--raw-data-source", required=False, type=str
-    )
-    parser.add_argument(
-        "-b", "--s3-bucket", required=False, type=str
-    )
-    parser.add_argument(
-        "-p", "--s3-prefix", required=False, type=str
-    )
-    parser.add_argument(
-        "-s", "--subject_id", required=False, type=str
-    )
-    job_args = parser.parse_args(args)
-
+# python -m aind_data_transfer.upload --subject 12345 --modality ecephys
+# --acq-date YYYY-MM-DD --acq-time HH-MM-SS <data_folder> <bucket>
+# <modality>_<subject_id>_<acq-date>_<acq-time>
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]
-    run_job(sys_args)
-
+    GenericS3UploadJob.run_job(sys_args)

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -23,7 +23,7 @@ from aind_data_transfer.util.s3_utils import (
 
 class GenericS3UploadJob:
 
-    UPLOAD_ENDPOINT_KEY = "upload_endpoints"
+    SERVICE_ENDPOINT_KEY = "service_endpoints"
     METADATA_SERVICE_URL_KEY = "metadata_service_url"
     CODEOCEAN_DOMAIN_KEY = "codeocean_domain"
     CODEOCEAN_CAPSULE_KEY = "codeocean_trigger_capsule"
@@ -36,16 +36,16 @@ class GenericS3UploadJob:
         self.configs = self._load_configs(args)
 
     def _get_endpoints(self, job_args, s3_region) -> Optional[dict]:
-        endpoints = getattr(job_args, self.UPLOAD_ENDPOINT_KEY)
+        endpoints = getattr(job_args, self.SERVICE_ENDPOINT_KEY)
         if not endpoints:
             try:
-                s3_secret_name = self.UPLOAD_ENDPOINT_KEY
+                s3_secret_name = self.SERVICE_ENDPOINT_KEY
                 get_secret(s3_secret_name, s3_region)
                 endpoints = json.loads(get_secret(s3_secret_name, s3_region))
             except ClientError as e:
                 logging.warning(
                     f"Unable to retrieve aws secret: "
-                    f"{self.UPLOAD_ENDPOINT_KEY}"
+                    f"{self.SERVICE_ENDPOINT_KEY}"
                 )
                 logging.debug(e.response)
                 endpoints = {}
@@ -170,9 +170,9 @@ class GenericS3UploadJob:
         parser.add_argument("-m", "--modality", required=True, type=str)
         parser.add_argument("-a", "--acq-date", required=True, type=str)
         parser.add_argument("-t", "--acq-time", required=True, type=str)
-        upload_endpoints_name = self.UPLOAD_ENDPOINT_KEY.replace("_", "-")
+        service_endpoints_name = self.SERVICE_ENDPOINT_KEY.replace("_", "-")
         parser.add_argument(
-            "-e", f"--{upload_endpoints_name}", required=False, type=str
+            "-e", f"--{service_endpoints_name}", required=False, type=str
         )
         parser.add_argument("-r", "--s3-region", required=False, type=str)
         parser.add_argument("--dry-run", action="store_true")
@@ -232,11 +232,6 @@ class GenericS3UploadJob:
             capsule_id=endpoints.get(self.CODEOCEAN_CAPSULE_KEY),
             dry_run=job_args.dry_run,
         )
-
-
-# python -m aind_data_transfer.upload --subject 12345 --modality ecephys
-# --acq-date YYYY-MM-DD --acq-time HH-MM-SS <data_folder> <bucket>
-# <modality>_<subject_id>_<acq-date>_<acq-time>
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -1,133 +1,237 @@
+import argparse
+import datetime
+import json
+import logging
+import os
+import sys
+import tempfile
+from typing import Optional
+
+from aind_codeocean_api.codeocean import CodeOceanClient
+from botocore.exceptions import ClientError
+
 from aind_data_transfer.transformations.metadata_creation import (
     DataDescriptionMetadata,
     SubjectMetadata,
 )
-
-import logging
-import json
-import sys
-import argparse
-import datetime
-import tempfile
-import os
-from aind_codeocean_api.codeocean import CodeOceanClient
-from aind_data_transfer.util.s3_utils import upload_to_s3, get_secret
+from aind_data_transfer.util.s3_utils import (
+    copy_to_s3,
+    get_secret,
+    upload_to_s3,
+)
 
 
 class GenericS3UploadJob:
 
-    upload_endpoints_keys = {"upload_endpoints": ["metadata_service_url",
-                                                  "codeocean_domain",
-                                                  "codeocean_trigger_capsule"]}
+    UPLOAD_ENDPOINT_KEY = "upload_endpoints"
+    METADATA_SERVICE_URL_KEY = "metadata_service_url"
+    CODEOCEAN_DOMAIN_KEY = "codeocean_domain"
+    CODEOCEAN_CAPSULE_KEY = "codeocean_trigger_capsule"
+    CODEOCEAN_TOKEN_KEY = "codeocean-api-token"
+    CODEOCEAN_READ_WRITE_KEY = "CODEOCEAN_READWRITE_TOKEN"
+    S3_DEFAULT_REGION = "us-west-2"
 
-    def run_job(self,
-                args: dict,
-                dryrun: bool = False,
-                s3_region="us-west-2") -> None:
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "-r", "--raw-data-source", required=True, type=str
-        )
-        parser.add_argument(
-            "-b", "--s3-bucket", required=True, type=str
-        )
-        parser.add_argument(
-            "-s", "--subject-id", required=True, type=str
-        )
-        parser.add_argument(
-            "-m", "--modality", required=True, type=str
-        )
-        parser.add_argument(
-            "-d", "--acq-date", required=True, type=str
-        )
-        parser.add_argument(
-            "-t", "--acq-time", required=True, type=str
-        )
-        parser.add_argument(
-            "-e", "--endpoints", required=False, type=str
-        )
+    def __init__(self, args: list):
+        self.args = args
+        self.configs = self._load_configs(args)
 
-        job_args = parser.parse_args(args)
-
-        s3_prefix = self.create_s3_prefix(job_args.modality,
-                                          job_args.subject_id,
-                                          job_args.acq_date,
-                                          job_args.acq_time)
-        data_prefix = "/".join([s3_prefix, job_args.modality])
-
-        upload_to_s3(directory_to_upload=job_args.raw_data_soucre,
-                     s3_bucket=job_args.s3_bucket,
-                     s3_prefix=data_prefix,
-                     dryrun=dryrun)
-
-        endpoints = job_args.get("endpoints")
+    def _get_endpoints(self, job_args, s3_region) -> Optional[dict]:
+        endpoints = getattr(job_args, self.UPLOAD_ENDPOINT_KEY)
         if not endpoints:
-            s3_secret_name = list(self.upload_endpoints_keys.keys())[0]
-            get_secret(s3_secret_name, s3_region)
-            endpoints = json.loads(get_secret(s3_secret_name, s3_region))
+            try:
+                s3_secret_name = self.UPLOAD_ENDPOINT_KEY
+                get_secret(s3_secret_name, s3_region)
+                endpoints = json.loads(get_secret(s3_secret_name, s3_region))
+            except ClientError as e:
+                logging.warning(
+                    f"Unable to retrieve aws secret: "
+                    f"{self.UPLOAD_ENDPOINT_KEY}"
+                )
+                logging.debug(e.response)
+                endpoints = {}
+        return endpoints
 
-        # Create subject.json file if metadata service url is provided
-        metadata_service_url = endpoints.get("metadata_service_url")
+    @staticmethod
+    def _upload_subject_metadata(
+        metadata_service_url, subject_id, s3_bucket, s3_prefix, dry_run
+    ) -> None:
         if metadata_service_url:
-            subject_metadata = (
-                SubjectMetadata.ephys_job_to_subject(
-                    metadata_service_url=metadata_service_url,
-                    subject_id=job_args.subect_id)
+            subject_metadata = SubjectMetadata.ephys_job_to_subject(
+                metadata_service_url=metadata_service_url,
+                subject_id=subject_id,
             )
-            subject_s3_prefix = SubjectMetadata.output_file_name
-            with tempfile.NamedTemporaryFile() as tmp:
+            file_name = SubjectMetadata.output_file_name
+            final_s3_prefix = "/".join([s3_prefix, file_name])
+            with tempfile.NamedTemporaryFile(mode="w") as tmp:
                 tmp.write(json.dumps(subject_metadata, indent=4))
-                upload_to_s3(directory_to_upload=tmp.name,
-                             s3_bucket=job_args.s3_bucket,
-                             s3_prefix=subject_s3_prefix,
-                             dryrun=dryrun)
+                copy_to_s3(
+                    file_to_upload=tmp.name,
+                    s3_bucket=s3_bucket,
+                    s3_prefix=final_s3_prefix,
+                    dryrun=dry_run,
+                )
+        else:
+            logging.warning(
+                "No metadata service url given. "
+                "Not able to get subject metadata."
+            )
 
-        # Create data description file
+    @staticmethod
+    def _upload_data_description_metadata(
+        s3_bucket, s3_prefix, dry_run
+    ) -> None:
         data_description_metadata = (
             DataDescriptionMetadata.get_data_description(name=s3_prefix)
         )
-        with tempfile.NamedTemporaryFile() as tmp:
+        file_name = DataDescriptionMetadata.output_file_name
+        final_s3_prefix = "/".join([s3_prefix, file_name])
+        with tempfile.NamedTemporaryFile(mode="w") as tmp:
             json_contents = data_description_metadata.json(indent=4)
             tmp.write(json_contents)
-            data_desc_s3_prefix = DataDescriptionMetadata.output_file_name
-            upload_to_s3(directory_to_upload=tmp.name,
-                         s3_bucket=job_args.s3_bucket,
-                         s3_prefix=data_desc_s3_prefix,
-                         dryrun=dryrun)
-
-        # Register to code ocean if url is provided
-        codeocean_url = endpoints.get("codeocean_url")
-        if codeocean_url:
-            logging.info("Triggering capsule run.")
-            capsule_id = endpoints.get("codeocean_trigger_capsule")
-            co_api_token = os.getenv("CODEOCEAN_API_TOKEN")
-            if co_api_token is None:
-                token_key_val = json.loads(
-                    get_secret("codeocean-api-token", "us-west-2"))
-                co_api_token = token_key_val["CODEOCEAN_READWRITE_TOKEN"]
-            co_domain = endpoints.get("codeocean_domain")
-            co_client = CodeOceanClient(domain=co_domain, token=co_api_token)
-            run_response = co_client.run_capsule(
-                capsule_id=capsule_id,
-                data_assets=[],
-                parameters=[],
+            copy_to_s3(
+                file_to_upload=tmp.name,
+                s3_bucket=s3_bucket,
+                s3_prefix=final_s3_prefix,
+                dryrun=dry_run,
             )
-            logging.debug(f"Run response: {run_response.json()}")
+
+    def _get_codeocean_client(self, s3_region, codeocean_domain):
+        # Try to see if it's been set by an env var
+        co_api_token = os.getenv(
+            f"{self.CODEOCEAN_TOKEN_KEY.replace('_', '-').upper()}"
+        )
+        # If not set by an env var, check if it's stored in aws secrets
+        if co_api_token is None:
+            try:
+                s3_secret_name = self.CODEOCEAN_TOKEN_KEY
+                get_secret(s3_secret_name, s3_region)
+                token_key_val = json.loads(
+                    get_secret(s3_secret_name, s3_region)
+                )
+                co_api_token = token_key_val.get(self.CODEOCEAN_READ_WRITE_KEY)
+            except ClientError as e:
+                logging.warning(
+                    f"Unable to retrieve aws secret: "
+                    f"{self.CODEOCEAN_TOKEN_KEY}"
+                )
+                logging.debug(e.response)
+        if co_api_token and codeocean_domain:
+            codeocean_client = CodeOceanClient(
+                domain=codeocean_domain, token=co_api_token
+            )
+        else:
+            codeocean_client = None
+        return codeocean_client
 
     @staticmethod
-    def create_s3_prefix(modality: str,
-                         subject_id: str,
-                         acq_date: str,
-                         acq_time: str) -> str:
+    def _trigger_codeocean_capsule(codeocean_client, capsule_id, dry_run):
+        if codeocean_client and capsule_id:
+            logging.info("Triggering capsule run.")
+            if not dry_run:
+                run_response = codeocean_client.run_capsule(
+                    capsule_id=capsule_id,
+                    data_assets=[],
+                    parameters=[],
+                )
+                logging.debug(f"Run response: {run_response.json()}")
+            else:
+                codeocean_client.get_capsule(capsule_id=capsule_id)
+                logging.info(
+                    f"Would have ran capsule: {capsule_id} "
+                    f"at {codeocean_client.domain}"
+                )
+        else:
+            logging.warning(
+                "CodeOcean endpoints are required to trigger capsule."
+            )
+
+    @staticmethod
+    def _create_s3_prefix(
+        modality: str, subject_id: str, acq_date: str, acq_time: str
+    ) -> str:
         # Validate date and time strings
         try:
-            datetime.datetime.strptime(acq_date + " " + acq_time,
-                                       '%Y-%m-%d %H-%M-%S')
+            datetime.datetime.strptime(
+                acq_date + " " + acq_time, "%Y-%m-%d %H-%M-%S"
+            )
         except ValueError:
-            raise ValueError("Incorrect data format, acq_date should be "
-                             "yyyy-MM-dd and acq_time should be HH-mm-SS")
+            raise ValueError(
+                "Incorrect data format, acq_date should be "
+                "yyyy-MM-dd and acq_time should be HH-mm-SS"
+            )
 
         return "_".join([modality, subject_id, acq_date, acq_time])
+
+    def _load_configs(self, args: list) -> argparse.Namespace:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-d", "--data-source", required=True, type=str)
+        parser.add_argument("-b", "--s3-bucket", required=True, type=str)
+        parser.add_argument("-s", "--subject-id", required=True, type=str)
+        parser.add_argument("-m", "--modality", required=True, type=str)
+        parser.add_argument("-a", "--acq-date", required=True, type=str)
+        parser.add_argument("-t", "--acq-time", required=True, type=str)
+        upload_endpoints_name = self.UPLOAD_ENDPOINT_KEY.replace("_", "-")
+        parser.add_argument(
+            "-e", f"--{upload_endpoints_name}", required=False, type=str
+        )
+        parser.add_argument("-r", "--s3-region", required=False, type=str)
+        parser.add_argument("--dry-run", action="store_true")
+        parser.set_defaults(dry_run=False)
+        parser.set_defaults(s3_region=self.S3_DEFAULT_REGION)
+
+        job_args = parser.parse_args(args)
+        return job_args
+
+    def run_job(self) -> None:
+
+        job_args = self._load_configs(self.args)
+        s3_region = job_args.s3_region
+
+        s3_prefix = self._create_s3_prefix(
+            job_args.modality,
+            job_args.subject_id,
+            job_args.acq_date,
+            job_args.acq_time,
+        )
+        data_prefix = "/".join([s3_prefix, job_args.modality])
+
+        upload_to_s3(
+            directory_to_upload=job_args.data_source,
+            s3_bucket=job_args.s3_bucket,
+            s3_prefix=data_prefix,
+            dryrun=job_args.dry_run,
+        )
+
+        endpoints = self._get_endpoints(job_args, s3_region)
+
+        # Create subject.json file if metadata service url is provided
+        self._upload_subject_metadata(
+            metadata_service_url=(
+                endpoints.get(self.METADATA_SERVICE_URL_KEY)
+            ),
+            subject_id=job_args.subject_id,
+            s3_bucket=job_args.s3_bucket,
+            s3_prefix=s3_prefix,
+            dry_run=job_args.dry_run,
+        )
+
+        # Create data description file
+        self._upload_data_description_metadata(
+            s3_bucket=job_args.s3_bucket,
+            s3_prefix=s3_prefix,
+            dry_run=job_args.dry_run,
+        )
+
+        # Register to code ocean if url is provided
+        codeocean_client = self._get_codeocean_client(
+            s3_region=s3_region,
+            codeocean_domain=endpoints.get("codeocean_domain"),
+        )
+        self._trigger_codeocean_capsule(
+            codeocean_client=codeocean_client,
+            capsule_id=endpoints.get(self.CODEOCEAN_CAPSULE_KEY),
+            dry_run=job_args.dry_run,
+        )
 
 
 # python -m aind_data_transfer.upload --subject 12345 --modality ecephys
@@ -136,4 +240,5 @@ class GenericS3UploadJob:
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]
-    GenericS3UploadJob.run_job(sys_args)
+    job = GenericS3UploadJob(sys_args)
+    job.run_job()

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -1,3 +1,5 @@
+"""Basic job to upload a data directory to s3 with some metadata attached."""
+
 import argparse
 import datetime
 import json
@@ -21,39 +23,57 @@ from aind_data_transfer.util.s3_utils import (
 
 
 class GenericS3UploadJob:
+    """Class for basic job construction."""
 
     SERVICE_ENDPOINT_KEY = "service_endpoints"
     METADATA_SERVICE_URL_KEY = "metadata_service_url"
     CODEOCEAN_DOMAIN_KEY = "codeocean_domain"
     CODEOCEAN_CAPSULE_KEY = "codeocean_trigger_capsule"
     CODEOCEAN_TOKEN_KEY = "codeocean-api-token"
+    CODEOCEAN_TOKEN_KEY_ENV = CODEOCEAN_TOKEN_KEY.replace("-", "_").upper()
     CODEOCEAN_READ_WRITE_KEY = "CODEOCEAN_READWRITE_TOKEN"
     S3_DEFAULT_REGION = "us-west-2"
 
-    def __init__(self, args: list):
+    def __init__(self, args: list) -> None:
+        """Initializes class with sys args. Convert the sys args to configs."""
         self.args = args
         self.configs = self._load_configs(args)
 
     @staticmethod
-    def _get_endpoints(service_endpoint_key, s3_region) -> dict:
+    def _get_endpoints(s3_region: str) -> dict:
+        """
+        If the service endpoints aren't set in the sys args, then this method
+        will try to pull them from aws secrets manager. It's static since it's
+        being called before the job is created.
+        Parameters
+        ----------
+        s3_region : str
+
+        Returns
+        -------
+        dict
+          Will return an empty dictionary if the service endpoints are not set
+          in sys args, or if they can't be pulled from aws secrets manager.
+
+        """
         try:
-            s3_secret_name = service_endpoint_key
+            s3_secret_name = GenericS3UploadJob.SERVICE_ENDPOINT_KEY
             get_secret(s3_secret_name, s3_region)
-            endpoints = json.loads(
-                get_secret(s3_secret_name, s3_region)
-            )
+            endpoints = json.loads(get_secret(s3_secret_name, s3_region))
         except ClientError as e:
             logging.warning(
                 f"Unable to retrieve aws secret: "
-                f"{service_endpoint_key}"
+                f"{GenericS3UploadJob.SERVICE_ENDPOINT_KEY}"
             )
             logging.debug(e.response)
             endpoints = {}
         return endpoints
 
-    def _upload_subject_metadata(self) -> None:
-        metadata_service_url = (
-            self.configs.service_endpoints.get("metadata_service_url")
+    def upload_subject_metadata(self) -> None:
+        """Retrieves subject metadata from metadata service and copies it to
+        s3. Logs warning if unable to retrieve metadata from service."""
+        metadata_service_url = self.configs.service_endpoints.get(
+            "metadata_service_url"
         )
         if metadata_service_url:
             subject_metadata = SubjectMetadata.ephys_job_to_subject(
@@ -76,41 +96,42 @@ class GenericS3UploadJob:
                 "Not able to get subject metadata."
             )
 
-    @staticmethod
-    def _upload_data_description_metadata(
-            s3_bucket,
-            s3_prefix,
-            dry_run
-    ) -> None:
+    def upload_data_description_metadata(self) -> None:
+        """Builds basic data description and copies it to s3."""
+
         data_description_metadata = (
-            DataDescriptionMetadata.get_data_description(name=s3_prefix)
+            DataDescriptionMetadata.get_data_description(name=self.s3_prefix)
         )
         file_name = DataDescriptionMetadata.output_file_name
-        final_s3_prefix = "/".join([s3_prefix, file_name])
+        final_s3_prefix = "/".join([self.s3_prefix, file_name])
         with tempfile.NamedTemporaryFile(mode="w") as tmp:
             json_contents = data_description_metadata.json(indent=4)
             tmp.write(json_contents)
             copy_to_s3(
                 file_to_upload=tmp.name,
-                s3_bucket=s3_bucket,
+                s3_bucket=self.configs.s3_bucket,
                 s3_prefix=final_s3_prefix,
-                dryrun=dry_run,
+                dryrun=self.configs.dry_run,
             )
 
-    def _get_codeocean_client(self,
-                              s3_region,
-                              codeocean_domain):
-        # Try to see if it's been set by an env var
-        co_api_token = os.getenv(
-            f"{self.CODEOCEAN_TOKEN_KEY.replace('_', '-').upper()}"
+    def _get_codeocean_client(self):
+        """Constructs a codeocean client. Will try to check if the api token
+        is set as an environment variable. If not set, then tries to retrieve
+        it from aws secrets manager. Otherwise, logs a warning and returns
+        None."""
+
+        codeocean_domain = self.configs.service_endpoints.get(
+            self.CODEOCEAN_DOMAIN_KEY
         )
+        # Try to see if api token is set by an env var
+        co_api_token = os.getenv(self.CODEOCEAN_TOKEN_KEY_ENV)
         # If not set by an env var, check if it's stored in aws secrets
         if co_api_token is None:
             try:
                 s3_secret_name = self.CODEOCEAN_TOKEN_KEY
-                get_secret(s3_secret_name, s3_region)
+                get_secret(s3_secret_name, self.configs.s3_region)
                 token_key_val = json.loads(
-                    get_secret(s3_secret_name, s3_region)
+                    get_secret(s3_secret_name, self.configs.s3_region)
                 )
                 co_api_token = token_key_val.get(self.CODEOCEAN_READ_WRITE_KEY)
             except ClientError as e:
@@ -127,13 +148,17 @@ class GenericS3UploadJob:
             codeocean_client = None
         return codeocean_client
 
-    @staticmethod
-    def _trigger_codeocean_capsule(codeocean_client,
-                                   capsule_id,
-                                   dry_run):
+    def trigger_codeocean_capsule(self):
+        """Triggers the codeocean capsule. Logs a warning if the endpoints
+        are not configured."""
+
+        capsule_id = self.configs.service_endpoints.get(
+            self.CODEOCEAN_CAPSULE_KEY
+        )
+        codeocean_client = self._get_codeocean_client()
         if codeocean_client and capsule_id:
             logging.info("Triggering capsule run.")
-            if not dry_run:
+            if not self.configs.dry_run:
                 run_response = codeocean_client.run_capsule(
                     capsule_id=capsule_id,
                     data_assets=[],
@@ -153,11 +178,13 @@ class GenericS3UploadJob:
 
     @property
     def s3_prefix(self):
+        """Constructs the s3_prefix from configs."""
+
         # Validate date and time strings
         try:
             datetime.datetime.strptime(
                 self.configs.acq_date + " " + self.configs.acq_time,
-                "%Y-%m-%d %H-%M-%S"
+                "%Y-%m-%d %H-%M-%S",
             )
         except ValueError:
             raise ValueError(
@@ -166,11 +193,18 @@ class GenericS3UploadJob:
             )
 
         return "_".join(
-            [self.configs.modality, self.configs.subject_id,
-             self.configs.acq_date, self.configs.acq_time]
+            [
+                self.configs.modality,
+                self.configs.subject_id,
+                self.configs.acq_date,
+                self.configs.acq_time,
+            ]
         )
 
     def _load_configs(self, args: list) -> argparse.Namespace:
+        """Parses sys args using argparse and resolves the service
+        endpoints."""
+
         parser = argparse.ArgumentParser()
         parser.add_argument("-d", "--data-source", required=True, type=str)
         parser.add_argument("-b", "--s3-bucket", required=True, type=str)
@@ -187,16 +221,14 @@ class GenericS3UploadJob:
         parser.set_defaults(s3_region=self.S3_DEFAULT_REGION)
         job_args = parser.parse_args(args)
         if not job_args.service_endpoints:
-            job_args.service_endpoints = (
-                self._get_endpoints(self.SERVICE_ENDPOINT_KEY,
-                                    job_args.s3_region
-                                    )
+            job_args.service_endpoints = self._get_endpoints(
+                job_args.s3_region
             )
         return job_args
 
     def run_job(self) -> None:
-
-        s3_region = self.configs.s3_region
+        """Uploads data folder to s3, then attempts to upload metadata to s3
+        and trigger the codeocean capsule."""
 
         data_prefix = "/".join([self.s3_prefix, self.configs.modality])
 
@@ -208,29 +240,13 @@ class GenericS3UploadJob:
         )
 
         # Create subject.json file if metadata service url is provided
-        self._upload_subject_metadata()
+        self.upload_subject_metadata()
 
         # Create data description file
-        self._upload_data_description_metadata(
-            s3_bucket=self.configs.s3_bucket,
-            s3_prefix=self.s3_prefix,
-            dry_run=self.configs.dry_run,
-        )
+        self.upload_data_description_metadata()
 
         # Register to code ocean if url is provided
-        codeocean_client = self._get_codeocean_client(
-            s3_region=s3_region,
-            codeocean_domain=self.configs.service_endpoints.get(
-                "codeocean_domain"
-            ),
-        )
-        self._trigger_codeocean_capsule(
-            codeocean_client=codeocean_client,
-            capsule_id=self.configs.service_endpoints.get(
-                self.CODEOCEAN_CAPSULE_KEY
-            ),
-            dry_run=self.configs.dry_run,
-        )
+        self.trigger_codeocean_capsule()
 
 
 if __name__ == "__main__":

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -220,7 +220,7 @@ class GenericS3UploadJob:
         parser.set_defaults(dry_run=False)
         parser.set_defaults(s3_region=self.S3_DEFAULT_REGION)
         job_args = parser.parse_args(args)
-        if not job_args.service_endpoints:
+        if job_args.service_endpoints is None:
             job_args.service_endpoints = self._get_endpoints(
                 job_args.s3_region
             )

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -1,0 +1,81 @@
+from aind_data_transfer.transformations.metadata_creation import (
+    ProcessingMetadata,
+    SubjectMetadata,
+)
+
+import logging
+import json
+import sys
+import argparse
+
+
+class GenericUploadJob:
+
+    @staticmethod
+    def attach_subject_info(subject_id,
+                            metadata_url,
+                            dest_data_dir) -> None:
+        """Writes subject metadata a destination directory"""
+        # Subject metadata
+        logging.info("Creating subject.json file.")
+        subject_instance = SubjectMetadata.ephys_job_to_subject(
+            metadata_url, subject_id, dest_data_dir.name
+        )
+        s_file_path = dest_data_dir / SubjectMetadata.output_file_name
+        if subject_instance is not None:
+            with open(s_file_path, "w") as f:
+                f.write(json.dumps(subject_instance, indent=4))
+            logging.info("Finished creating subject.json file.")
+        else:
+            logging.warning("No subject.json file created!")
+
+    @staticmethod
+    def attach_processing_info(dest_data_dir,
+                               start_date_time,
+                               end_date_time,
+                               input_location,
+                               output_location,
+                               code_url,
+                               parameters) -> None:
+        """Writes processing metadata a destination directory"""
+
+        # Processing metadata
+        logging.info("Creating processing.json file.")
+        processing_instance = ProcessingMetadata.ephys_job_to_processing(
+            start_date_time=start_date_time,
+            end_date_time=end_date_time,
+            input_location=str(input_location),
+            output_location=output_location,
+            code_url=code_url,
+            parameters=parameters,
+            notes=None,
+        )
+
+        file_path = dest_data_dir / ProcessingMetadata.output_file_name
+        with open(file_path, "w") as f:
+            contents = processing_instance.json(**{"indent": 4})
+            f.write(contents)
+        logging.info("Finished creating processing.json file.")
+
+
+def run_job(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-r", "--raw-data-source", required=False, type=str
+    )
+    parser.add_argument(
+        "-b", "--s3-bucket", required=False, type=str
+    )
+    parser.add_argument(
+        "-p", "--s3-prefix", required=False, type=str
+    )
+    parser.add_argument(
+        "-s", "--subject_id", required=False, type=str
+    )
+    job_args = parser.parse_args(args)
+
+
+if __name__ == "__main__":
+    sys_args = sys.argv[1:]
+    run_job(sys_args)
+

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -13,7 +13,7 @@ from aind_codeocean_api.codeocean import CodeOceanClient
 from botocore.exceptions import ClientError
 
 from aind_data_transfer.transformations.metadata_creation import (
-    DataDescriptionMetadata,
+    RawDataDescriptionMetadata,
     SubjectMetadata,
 )
 from aind_data_transfer.util.s3_utils import (
@@ -106,9 +106,11 @@ class GenericS3UploadJob:
         """Builds basic data description and copies it to s3."""
 
         data_description_metadata = (
-            DataDescriptionMetadata.get_data_description(name=self.s3_prefix)
+            RawDataDescriptionMetadata.get_data_description(
+                name=self.s3_prefix
+            )
         )
-        file_name = DataDescriptionMetadata.output_file_name
+        file_name = RawDataDescriptionMetadata.output_file_name
         final_s3_prefix = "/".join([self.s3_prefix, file_name])
         with tempfile.NamedTemporaryFile(mode="w") as tmp:
             json_contents = data_description_metadata.json(indent=4)

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -5,7 +5,6 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Optional
 
 from aind_codeocean_api.codeocean import CodeOceanClient
 from botocore.exceptions import ClientError
@@ -35,40 +34,41 @@ class GenericS3UploadJob:
         self.args = args
         self.configs = self._load_configs(args)
 
-    def _get_endpoints(self, job_args, s3_region) -> Optional[dict]:
-        endpoints = getattr(job_args, self.SERVICE_ENDPOINT_KEY)
-        if not endpoints:
-            try:
-                s3_secret_name = self.SERVICE_ENDPOINT_KEY
+    @staticmethod
+    def _get_endpoints(service_endpoint_key, s3_region) -> dict:
+        try:
+            s3_secret_name = service_endpoint_key
+            get_secret(s3_secret_name, s3_region)
+            endpoints = json.loads(
                 get_secret(s3_secret_name, s3_region)
-                endpoints = json.loads(get_secret(s3_secret_name, s3_region))
-            except ClientError as e:
-                logging.warning(
-                    f"Unable to retrieve aws secret: "
-                    f"{self.SERVICE_ENDPOINT_KEY}"
-                )
-                logging.debug(e.response)
-                endpoints = {}
+            )
+        except ClientError as e:
+            logging.warning(
+                f"Unable to retrieve aws secret: "
+                f"{service_endpoint_key}"
+            )
+            logging.debug(e.response)
+            endpoints = {}
         return endpoints
 
-    @staticmethod
-    def _upload_subject_metadata(
-        metadata_service_url, subject_id, s3_bucket, s3_prefix, dry_run
-    ) -> None:
+    def _upload_subject_metadata(self) -> None:
+        metadata_service_url = (
+            self.configs.service_endpoints.get("metadata_service_url")
+        )
         if metadata_service_url:
             subject_metadata = SubjectMetadata.ephys_job_to_subject(
                 metadata_service_url=metadata_service_url,
-                subject_id=subject_id,
+                subject_id=self.configs.subject_id,
             )
             file_name = SubjectMetadata.output_file_name
-            final_s3_prefix = "/".join([s3_prefix, file_name])
+            final_s3_prefix = "/".join([self.s3_prefix, file_name])
             with tempfile.NamedTemporaryFile(mode="w") as tmp:
                 tmp.write(json.dumps(subject_metadata, indent=4))
                 copy_to_s3(
                     file_to_upload=tmp.name,
-                    s3_bucket=s3_bucket,
+                    s3_bucket=self.configs.s3_bucket,
                     s3_prefix=final_s3_prefix,
-                    dryrun=dry_run,
+                    dryrun=self.configs.dry_run,
                 )
         else:
             logging.warning(
@@ -78,7 +78,9 @@ class GenericS3UploadJob:
 
     @staticmethod
     def _upload_data_description_metadata(
-        s3_bucket, s3_prefix, dry_run
+            s3_bucket,
+            s3_prefix,
+            dry_run
     ) -> None:
         data_description_metadata = (
             DataDescriptionMetadata.get_data_description(name=s3_prefix)
@@ -95,7 +97,9 @@ class GenericS3UploadJob:
                 dryrun=dry_run,
             )
 
-    def _get_codeocean_client(self, s3_region, codeocean_domain):
+    def _get_codeocean_client(self,
+                              s3_region,
+                              codeocean_domain):
         # Try to see if it's been set by an env var
         co_api_token = os.getenv(
             f"{self.CODEOCEAN_TOKEN_KEY.replace('_', '-').upper()}"
@@ -124,7 +128,9 @@ class GenericS3UploadJob:
         return codeocean_client
 
     @staticmethod
-    def _trigger_codeocean_capsule(codeocean_client, capsule_id, dry_run):
+    def _trigger_codeocean_capsule(codeocean_client,
+                                   capsule_id,
+                                   dry_run):
         if codeocean_client and capsule_id:
             logging.info("Triggering capsule run.")
             if not dry_run:
@@ -145,14 +151,13 @@ class GenericS3UploadJob:
                 "CodeOcean endpoints are required to trigger capsule."
             )
 
-    @staticmethod
-    def _create_s3_prefix(
-        modality: str, subject_id: str, acq_date: str, acq_time: str
-    ) -> str:
+    @property
+    def s3_prefix(self):
         # Validate date and time strings
         try:
             datetime.datetime.strptime(
-                acq_date + " " + acq_time, "%Y-%m-%d %H-%M-%S"
+                self.configs.acq_date + " " + self.configs.acq_time,
+                "%Y-%m-%d %H-%M-%S"
             )
         except ValueError:
             raise ValueError(
@@ -160,7 +165,10 @@ class GenericS3UploadJob:
                 "yyyy-MM-dd and acq_time should be HH-mm-SS"
             )
 
-        return "_".join([modality, subject_id, acq_date, acq_time])
+        return "_".join(
+            [self.configs.modality, self.configs.subject_id,
+             self.configs.acq_date, self.configs.acq_time]
+        )
 
     def _load_configs(self, args: list) -> argparse.Namespace:
         parser = argparse.ArgumentParser()
@@ -170,68 +178,60 @@ class GenericS3UploadJob:
         parser.add_argument("-m", "--modality", required=True, type=str)
         parser.add_argument("-a", "--acq-date", required=True, type=str)
         parser.add_argument("-t", "--acq-time", required=True, type=str)
-        service_endpoints_name = self.SERVICE_ENDPOINT_KEY.replace("_", "-")
         parser.add_argument(
-            "-e", f"--{service_endpoints_name}", required=False, type=str
+            "-e", "--service-endpoints", required=False, type=json.loads
         )
         parser.add_argument("-r", "--s3-region", required=False, type=str)
         parser.add_argument("--dry-run", action="store_true")
         parser.set_defaults(dry_run=False)
         parser.set_defaults(s3_region=self.S3_DEFAULT_REGION)
-
         job_args = parser.parse_args(args)
+        if not job_args.service_endpoints:
+            job_args.service_endpoints = (
+                self._get_endpoints(self.SERVICE_ENDPOINT_KEY,
+                                    job_args.s3_region
+                                    )
+            )
         return job_args
 
     def run_job(self) -> None:
 
-        job_args = self._load_configs(self.args)
-        s3_region = job_args.s3_region
+        s3_region = self.configs.s3_region
 
-        s3_prefix = self._create_s3_prefix(
-            job_args.modality,
-            job_args.subject_id,
-            job_args.acq_date,
-            job_args.acq_time,
-        )
-        data_prefix = "/".join([s3_prefix, job_args.modality])
+        data_prefix = "/".join([self.s3_prefix, self.configs.modality])
 
         upload_to_s3(
-            directory_to_upload=job_args.data_source,
-            s3_bucket=job_args.s3_bucket,
+            directory_to_upload=self.configs.data_source,
+            s3_bucket=self.configs.s3_bucket,
             s3_prefix=data_prefix,
-            dryrun=job_args.dry_run,
+            dryrun=self.configs.dry_run,
         )
-
-        endpoints = self._get_endpoints(job_args, s3_region)
 
         # Create subject.json file if metadata service url is provided
-        self._upload_subject_metadata(
-            metadata_service_url=(
-                endpoints.get(self.METADATA_SERVICE_URL_KEY)
-            ),
-            subject_id=job_args.subject_id,
-            s3_bucket=job_args.s3_bucket,
-            s3_prefix=s3_prefix,
-            dry_run=job_args.dry_run,
-        )
+        self._upload_subject_metadata()
 
         # Create data description file
         self._upload_data_description_metadata(
-            s3_bucket=job_args.s3_bucket,
-            s3_prefix=s3_prefix,
-            dry_run=job_args.dry_run,
+            s3_bucket=self.configs.s3_bucket,
+            s3_prefix=self.s3_prefix,
+            dry_run=self.configs.dry_run,
         )
 
         # Register to code ocean if url is provided
         codeocean_client = self._get_codeocean_client(
             s3_region=s3_region,
-            codeocean_domain=endpoints.get("codeocean_domain"),
+            codeocean_domain=self.configs.service_endpoints.get(
+                "codeocean_domain"
+            ),
         )
         self._trigger_codeocean_capsule(
             codeocean_client=codeocean_client,
-            capsule_id=endpoints.get(self.CODEOCEAN_CAPSULE_KEY),
-            dry_run=job_args.dry_run,
+            capsule_id=self.configs.service_endpoints.get(
+                self.CODEOCEAN_CAPSULE_KEY
+            ),
+            dry_run=self.configs.dry_run,
         )
+
 
 if __name__ == "__main__":
     sys_args = sys.argv[1:]

--- a/src/aind_data_transfer/transformations/metadata_creation.py
+++ b/src/aind_data_transfer/transformations/metadata_creation.py
@@ -77,7 +77,7 @@ class ProcessingMetadata:
 class SubjectMetadata:
     """Class to handle the creation of the subject metadata file."""
 
-    output_file_name = Subject._get_default_filename()
+    output_file_name = Subject.construct()._get_default_filename()
 
     @staticmethod
     def get_subject_metadata(metadata_service_url: str,
@@ -164,7 +164,7 @@ class SubjectMetadata:
 class DataDescriptionMetadata:
     """Class to handle the creation of the processing metadata file."""
 
-    output_file_name = RawDataDescription._get_default_filename()
+    output_file_name = RawDataDescription.construct()._get_default_filename()
 
     @staticmethod
     def get_data_description(

--- a/src/aind_data_transfer/transformations/metadata_creation.py
+++ b/src/aind_data_transfer/transformations/metadata_creation.py
@@ -12,6 +12,7 @@ from aind_data_schema.data_description import (
 )
 from aind_data_schema.processing import DataProcess, Processing, ProcessName
 from aind_data_schema.subject import Subject
+
 import aind_data_transfer
 
 
@@ -19,7 +20,7 @@ class ProcessingMetadata:
     """Class to handle the creation of the processing metadata file."""
 
     # TODO: import this from aind_data_schema.Processing class
-    output_file_name = "processing.json"
+    output_file_name = Processing.construct().default_filename()
 
     @staticmethod
     def ephys_job_to_processing(
@@ -77,11 +78,12 @@ class ProcessingMetadata:
 class SubjectMetadata:
     """Class to handle the creation of the subject metadata file."""
 
-    output_file_name = Subject.construct()._get_default_filename()
+    output_file_name = Subject.construct().default_filename()
 
     @staticmethod
-    def get_subject_metadata(metadata_service_url: str,
-                             subject_id: str) -> Optional[dict]:
+    def get_subject_metadata(
+        metadata_service_url: str, subject_id: str
+    ) -> Optional[dict]:
         # TODO: construct this from aind_metadata_service.client
         subject_url = metadata_service_url + f"/subject/{subject_id}"
         response = requests.get(subject_url)
@@ -161,10 +163,10 @@ class SubjectMetadata:
             return None
 
 
-class DataDescriptionMetadata:
+class RawDataDescriptionMetadata:
     """Class to handle the creation of the processing metadata file."""
 
-    output_file_name = RawDataDescription.construct()._get_default_filename()
+    output_file_name = RawDataDescription.construct().default_filename()
 
     @staticmethod
     def get_data_description(

--- a/src/aind_data_transfer/transformations/metadata_creation.py
+++ b/src/aind_data_transfer/transformations/metadata_creation.py
@@ -11,7 +11,7 @@ from aind_data_schema.data_description import (
     RawDataDescription,
 )
 from aind_data_schema.processing import DataProcess, Processing, ProcessName
-
+from aind_data_schema.subject import Subject
 import aind_data_transfer
 
 
@@ -77,7 +77,31 @@ class ProcessingMetadata:
 class SubjectMetadata:
     """Class to handle the creation of the subject metadata file."""
 
-    output_file_name = "subject.json"
+    output_file_name = Subject._get_default_filename()
+
+    @staticmethod
+    def get_subject_metadata(metadata_service_url: str,
+                             subject_id: str) -> Optional[dict]:
+        # TODO: construct this from aind_metadata_service.client
+        subject_url = metadata_service_url + f"/subject/{subject_id}"
+        response = requests.get(subject_url)
+
+        if response.status_code == 200:
+            response_json = response.json()
+            response_data = response_json["data"]
+            return response_data
+        elif response.status_code == 418:
+            response_json = response.json()
+            logging.warning(response_json["message"])
+            response_data_original = response_json["data"]
+            if type(response_data_original) == list:
+                response_data = response_data_original[0]
+            else:
+                response_data = response_data_original
+            return response_data
+        else:
+            logging.error("No data retrieved!")
+            return None
 
     @staticmethod
     def ephys_job_to_subject(
@@ -87,7 +111,7 @@ class SubjectMetadata:
         file_subject_regex: Optional[str] = (
             "(ecephys|ephys)*_*(\\d+)_\\d{4}"
         ),
-    ) -> dict:
+    ) -> Optional[dict]:
         """
 
         Parameters
@@ -136,17 +160,20 @@ class SubjectMetadata:
             logging.error("No data retrieved!")
             return None
 
+
 class DataDescriptionMetadata:
     """Class to handle the creation of the processing metadata file."""
 
+    output_file_name = RawDataDescription._get_default_filename()
+
     @staticmethod
-    def ephys_job_to_data_description(
+    def get_data_description(
         name: str,
         institution=Institution.AIND,
         funding_source=(Funding(funder=Institution.AIND.value),),
     ) -> RawDataDescription:
         """
-        Creates a data description instance based on the openephys_job settings
+        Creates a data description instance
         Parameters
         ----------
         name : str

--- a/src/aind_data_transfer/transformations/metadata_creation.py
+++ b/src/aind_data_transfer/transformations/metadata_creation.py
@@ -130,3 +130,4 @@ class SubjectMetadata:
         else:
             logging.error("No data retrieved!")
             return None
+

--- a/src/aind_data_transfer/util/s3_utils.py
+++ b/src/aind_data_transfer/util/s3_utils.py
@@ -62,3 +62,36 @@ def upload_to_s3(directory_to_upload,
             shell=shell
         )
     logging.info("Finished uploading to s3.")
+
+
+def copy_to_s3(file_to_upload,
+               s3_bucket,
+               s3_prefix,
+               dryrun):
+    # Upload to s3
+    if platform.system() == "Windows":
+        shell = True
+    else:
+        shell = False
+
+    # TODO: Use s3transfer library instead of subprocess?
+    logging.info("Uploading to s3.")
+    aws_dest = f"s3://{s3_bucket}/{s3_prefix}"
+    if dryrun:
+        subprocess.run(
+            [
+                "aws",
+                "s3",
+                "cp",
+                file_to_upload,
+                aws_dest,
+                "--dryrun",
+            ],
+            shell=shell,
+        )
+    else:
+        subprocess.run(
+            ["aws", "s3", "cp", file_to_upload, aws_dest],
+            shell=shell
+        )
+    logging.info("Finished uploading to s3.")

--- a/src/aind_data_transfer/util/s3_utils.py
+++ b/src/aind_data_transfer/util/s3_utils.py
@@ -1,8 +1,9 @@
 import logging
-import boto3
-from botocore.exceptions import ClientError
 import platform
 import subprocess
+
+import boto3
+from botocore.exceptions import ClientError
 
 
 def get_secret(secret_name, region_name):
@@ -31,10 +32,7 @@ def get_secret(secret_name, region_name):
     return secret
 
 
-def upload_to_s3(directory_to_upload,
-                 s3_bucket,
-                 s3_prefix,
-                 dryrun):
+def upload_to_s3(directory_to_upload, s3_bucket, s3_prefix, dryrun):
     # Upload to s3
     if platform.system() == "Windows":
         shell = True
@@ -58,16 +56,12 @@ def upload_to_s3(directory_to_upload,
         )
     else:
         subprocess.run(
-            ["aws", "s3", "sync", directory_to_upload, aws_dest],
-            shell=shell
+            ["aws", "s3", "sync", directory_to_upload, aws_dest], shell=shell
         )
     logging.info("Finished uploading to s3.")
 
 
-def copy_to_s3(file_to_upload,
-               s3_bucket,
-               s3_prefix,
-               dryrun):
+def copy_to_s3(file_to_upload, s3_bucket, s3_prefix, dryrun):
     # Upload to s3
     if platform.system() == "Windows":
         shell = True
@@ -75,7 +69,7 @@ def copy_to_s3(file_to_upload,
         shell = False
 
     # TODO: Use s3transfer library instead of subprocess?
-    logging.info("Uploading to s3.")
+    logging.info("Copying file to s3.")
     aws_dest = f"s3://{s3_bucket}/{s3_prefix}"
     if dryrun:
         subprocess.run(
@@ -91,7 +85,6 @@ def copy_to_s3(file_to_upload,
         )
     else:
         subprocess.run(
-            ["aws", "s3", "cp", file_to_upload, aws_dest],
-            shell=shell
+            ["aws", "s3", "cp", file_to_upload, aws_dest], shell=shell
         )
-    logging.info("Finished uploading to s3.")
+    logging.info("Finished copying file to s3.")

--- a/src/aind_data_transfer/util/s3_utils.py
+++ b/src/aind_data_transfer/util/s3_utils.py
@@ -1,5 +1,8 @@
+import logging
 import boto3
 from botocore.exceptions import ClientError
+import platform
+import subprocess
 
 
 def get_secret(secret_name, region_name):
@@ -26,3 +29,36 @@ def get_secret(secret_name, region_name):
     secret = get_secret_value_response["SecretString"]
 
     return secret
+
+
+def upload_to_s3(directory_to_upload,
+                 s3_bucket,
+                 s3_prefix,
+                 dryrun):
+    # Upload to s3
+    if platform.system() == "Windows":
+        shell = True
+    else:
+        shell = False
+
+    # TODO: Use s3transfer library instead of subprocess?
+    logging.info("Uploading to s3.")
+    aws_dest = f"s3://{s3_bucket}/{s3_prefix}"
+    if dryrun:
+        subprocess.run(
+            [
+                "aws",
+                "s3",
+                "sync",
+                directory_to_upload,
+                aws_dest,
+                "--dryrun",
+            ],
+            shell=shell,
+        )
+    else:
+        subprocess.run(
+            ["aws", "s3", "sync", directory_to_upload, aws_dest],
+            shell=shell
+        )
+    logging.info("Finished uploading to s3.")

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -1,33 +1,104 @@
+"""Test module for generic upload job."""
+
+import json
+import os
 import unittest
 from io import StringIO
-from unittest.mock import patch, Mock
-import json
+from unittest.mock import MagicMock, Mock, call, mock_open, patch
+
+from aind_codeocean_api.codeocean import CodeOceanClient
 from botocore.exceptions import ClientError
+
 from aind_data_transfer.jobs.s3_upload_job import GenericS3UploadJob
 
 
-class TestProcessingMetadata(unittest.TestCase):
+class TestGenericS3UploadJob(unittest.TestCase):
+    """Unit tests for methods in GenericS3UploadJob class."""
 
+    # Some fake args that can be used to construct a basic job
     fake_endpoints_str = (
-            '{"metadata_service_url": "http://metada_service_url",'
-            '"codeocean_domain": "https://codeocean.acme.org",'
-            '"codeocean_trigger_capsule": "abc-123",'
-            '"codeocean-api-token": "some_token"}'
-        )
-    args1 = (
-        ["-d", "some_dir", "-b", "some_s3_bucket", "-s", "12345",
-         "-m", "ecephys", "-a", "2022-10-10", "-t", "13-24-01",
-         "-e", fake_endpoints_str, "--dry-run"]
+        '{"metadata_service_url": "http://metada_service_url",'
+        '"codeocean_domain": "https://codeocean.acme.org",'
+        '"codeocean_trigger_capsule": "abc-123",'
+        '"codeocean-api-token": "some_token"}'
     )
+    args1 = [
+        "-d",
+        "some_dir",
+        "-b",
+        "some_s3_bucket",
+        "-s",
+        "12345",
+        "-m",
+        "ecephys",
+        "-a",
+        "2022-10-10",
+        "-t",
+        "13-24-01",
+        "-e",
+        fake_endpoints_str,
+        "--dry-run",
+    ]
 
-    def test_create_s3_prefix(self):
+    @staticmethod
+    def _mock_boto_get_secret_session(secret_string: str) -> MagicMock:
+        """
+        Utility method to return a mocked boto session. A call to client method
+         get_secret_value will return {'SecretString': secret_string}
+        Parameters
+        ----------
+        secret_string : A mock string attached to get_secret_value
+
+        Returns
+        -------
+        MagicMock
+          A mocked boto session object
+
+        """
+        mock_session_object = Mock()
+        mock_client = Mock()
+        mock_client.get_secret_value.return_value = {
+            "SecretString": secret_string
+        }
+        mock_session_object.client.return_value = mock_client
+        return mock_session_object
+
+    @staticmethod
+    def _mock_boto_get_secret_session_error() -> MagicMock:
+        """
+        Utility method to return a mocked boto session. A call to client method
+         get_secret_value will raise a ClientError exception
+
+        Returns
+        -------
+        MagicMock
+          A mocked boto session object
+
+        """
+        mock_session_object = Mock()
+        mock_client = Mock()
+        mock_client.get_secret_value.side_effect = Mock(
+            side_effect=ClientError(
+                error_response=(
+                    {"Error": {"Code": "500", "Message": "Error"}}
+                ),
+                operation_name=None,
+            )
+        )
+        mock_session_object.client.return_value = mock_client
+        return mock_session_object
+
+    def test_create_s3_prefix(self) -> None:
+        """Tests that a s3 prefix is created correctly from job configs."""
         job = GenericS3UploadJob(self.args1)
 
         expected_s3_prefix = "ecephys_12345_2022-10-10_13-24-01"
         actual_s3_prefix = job.s3_prefix
         self.assertEqual(expected_s3_prefix, actual_s3_prefix)
 
-    def test_create_s3_prefix_error(self):
+    def test_create_s3_prefix_error(self) -> None:
+        """Tests that errors are raised if the data/time strings are
+        malformed."""
         bad_args = self.args1.copy()
 
         with self.assertRaises(ValueError):
@@ -51,96 +122,295 @@ class TestProcessingMetadata(unittest.TestCase):
             bad_args[11] = "12-59-60"  # Bad Second
             GenericS3UploadJob(bad_args).s3_prefix()
 
-    @patch('sys.stderr', new_callable=StringIO)
-    def test_load_configs(self, mock_stderr):
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_load_configs(self, mock_stderr: MagicMock) -> None:
+        """Tests that the sysargs are parsed correctly."""
         job = GenericS3UploadJob(self.args1)
-        expected_configs_vars = (
-            {"data_source": "some_dir",
-             "s3_bucket": "some_s3_bucket",
-             "subject_id": "12345",
-             "modality": "ecephys",
-             "acq_date": "2022-10-10",
-             "acq_time": "13-24-01",
-             "s3_region": "us-west-2",
-             "service_endpoints": json.loads(self.fake_endpoints_str),
-             "dry_run": True}
-        )
+        expected_configs_vars = {
+            "data_source": "some_dir",
+            "s3_bucket": "some_s3_bucket",
+            "subject_id": "12345",
+            "modality": "ecephys",
+            "acq_date": "2022-10-10",
+            "acq_time": "13-24-01",
+            "s3_region": "us-west-2",
+            "service_endpoints": json.loads(self.fake_endpoints_str),
+            "dry_run": True,
+        }
         self.assertEqual(expected_configs_vars, vars(job.configs))
 
-        missing_arg = (
-            ["-d", "some_dir", "-b", "some_s3_bucket", "-s", "12345",
-             "-m", "ecephys", "-a", "2022-10-10"]
-        )
+        missing_arg = [
+            "-d",
+            "some_dir",
+            "-b",
+            "some_s3_bucket",
+            "-s",
+            "12345",
+            "-m",
+            "ecephys",
+            "-a",
+            "2022-10-10",
+        ]
 
         with self.assertRaises(SystemExit):
             GenericS3UploadJob(missing_arg)
         self.assertRegexpMatches(
             mock_stderr.getvalue(),
-            r"the following arguments are required: -t/--acq-time"
+            r"the following arguments are required: -t/--acq-time",
         )
 
-    @patch('logging.Logger.warning')
+    @patch("logging.Logger.warning")
     @patch("boto3.session.Session")
-    def test_get_endpoints(self, mock_session, mock_log):
+    def test_get_endpoints(
+        self, mock_session: MagicMock, mock_log: MagicMock
+    ) -> None:
+        """Tests that the service endpoints are loaded correctly either from
+        being set in the sys args or pulled from aws Secrets Manager"""
         job = GenericS3UploadJob(self.args1)
         expected_endpoints1 = json.loads(self.fake_endpoints_str)
         self.assertEqual(expected_endpoints1, job.configs.service_endpoints)
 
         # Check job loads endpoints from s3 secrets
-        args_without_endpoints = (
-            ["-d", "some_dir", "-b", "some_s3_bucket", "-s", "12345",
-             "-m", "ecephys", "-a", "2022-10-10", "-t", "10-10-00",
-             "--dry-run"]
+        args_without_endpoints = [
+            "-d",
+            "some_dir",
+            "-b",
+            "some_s3_bucket",
+            "-s",
+            "12345",
+            "-m",
+            "ecephys",
+            "-a",
+            "2022-10-10",
+            "-t",
+            "10-10-00",
+            "--dry-run",
+        ]
+        mock_session.return_value = self._mock_boto_get_secret_session(
+            self.fake_endpoints_str
         )
-        mock_session_object = Mock()
-        mock_client = Mock()
-        mock_client.get_secret_value.return_value = ({
-            'SecretString': self.fake_endpoints_str
-        })
-        mock_session_object.client.return_value = mock_client
-        mock_session.return_value = mock_session_object
         job2 = GenericS3UploadJob(args_without_endpoints)
         self.assertEqual(expected_endpoints1, job2.configs.service_endpoints)
 
         # Check endpoints are empty if not in sys args or in aws
-        mock_client.get_secret_value.side_effect = Mock(
-            side_effect=ClientError(
-                error_response=({
-                    'Error': {'Code': '500', 'Message': 'Error'}
-                }),
-                operation_name=None)
-        )
+        mock_session.return_value = self._mock_boto_get_secret_session_error()
         job3 = GenericS3UploadJob(args_without_endpoints)
         self.assertEqual({}, job3.configs.service_endpoints)
         mock_log.assert_called_with(
             f"Unable to retrieve aws secret: {job3.SERVICE_ENDPOINT_KEY}"
         )
 
-    @patch('aind_data_transfer.jobs.s3_upload_job.copy_to_s3')
-    @patch('logging.Logger.warning')
+    @patch("aind_data_transfer.jobs.s3_upload_job.copy_to_s3")
+    @patch("logging.Logger.warning")
     @patch(
-        'aind_data_transfer.transformations.metadata_creation.SubjectMetadata.'
-        'ephys_job_to_subject'
+        "aind_data_transfer.transformations.metadata_creation.SubjectMetadata."
+        "ephys_job_to_subject"
     )
-    @patch('tempfile.NamedTemporaryFile')
-    def test_upload_subject_metadata(self,
-                                     mocked_tempfile,
-                                     mocked_ephys_job_to_subject,
-                                     mock_log,
-                                     mock_copy_to_s3):
+    @patch("tempfile.NamedTemporaryFile", new_callable=mock_open())
+    @patch("boto3.session.Session")
+    def test_upload_subject_metadata(
+        self,
+        mock_session: MagicMock,
+        mocked_tempfile: MagicMock,
+        mocked_ephys_job_to_subject: MagicMock,
+        mock_log: MagicMock,
+        mock_copy_to_s3: MagicMock,
+    ) -> None:
+        """Tests that subject data is uploaded correctly."""
+
+        # Check that tempfile is called and copy to s3 is called
+        mock_session.return_value = self._mock_boto_get_secret_session_error()
         mocked_ephys_job_to_subject.return_value = {}
         job = GenericS3UploadJob(self.args1)
-        job._upload_subject_metadata()
-        mock_copy_to_s3.assert_called_once()
-        mocked_tempfile.assert_called_once()
+        job.upload_subject_metadata()
+        tmp_file_handle = mocked_tempfile.return_value.__enter__()
+        tmp_file_handle.write.assert_called_once()
+        mock_copy_to_s3.assert_called_once_with(
+            file_to_upload=tmp_file_handle.name,
+            s3_bucket="some_s3_bucket",
+            s3_prefix=("ecephys_12345_2022-10-10_13-24-01/subject.json"),
+            dryrun=True,
+        )
 
         # Check warning message if not metadata url is found
         empty_args = self.args1.copy()
-        empty_args[13] = '{}'
+        empty_args[13] = "{}"
         job2 = GenericS3UploadJob(empty_args)
-        job2._upload_subject_metadata()
-        mock_log.assert_called_with(
-            "No metadata service url given. Not able to get subject metadata."
+        job2.upload_subject_metadata()
+        mock_log.assert_has_calls(
+            [
+                call(
+                    f"Unable to retrieve aws secret: "
+                    f"{job2.SERVICE_ENDPOINT_KEY}"
+                ),
+                call(
+                    "No metadata service url given. "
+                    "Not able to get subject metadata."
+                ),
+            ]
         )
 
+    @patch("aind_data_transfer.jobs.s3_upload_job.copy_to_s3")
+    @patch("logging.Logger.warning")
+    @patch("tempfile.NamedTemporaryFile", new_callable=mock_open())
+    @patch("boto3.session.Session")
+    def test_upload_data_description_metadata(
+        self,
+        mock_session: MagicMock,
+        mocked_tempfile: MagicMock,
+        mock_log: MagicMock,
+        mock_copy_to_s3: MagicMock,
+    ) -> None:
+        """Tests data description is uploaded correctly."""
 
+        # Check that tempfile is called and copy to s3 is called
+        mock_session.return_value = self._mock_boto_get_secret_session_error()
+        job = GenericS3UploadJob(self.args1)
+        job.upload_data_description_metadata()
+        tmp_file_handle = mocked_tempfile.return_value.__enter__()
+        mock_copy_to_s3.assert_called_once_with(
+            file_to_upload=tmp_file_handle.name,
+            s3_bucket="some_s3_bucket",
+            s3_prefix=(
+                "ecephys_12345_2022-10-10_13-24-01/rawdatadescription.json"
+            ),
+            dryrun=True,
+        )
+        tmp_file_handle.write.assert_called_once()
+
+        # Check warning message if not metadata url is found
+        empty_args = self.args1.copy()
+        empty_args[13] = "{}"
+        job2 = GenericS3UploadJob(empty_args)
+        job2.upload_data_description_metadata()
+        mock_log.assert_called_with(
+            f"Unable to retrieve aws secret: {job.SERVICE_ENDPOINT_KEY}"
+        )
+
+    @patch.dict(
+        os.environ,
+        ({f"{GenericS3UploadJob.CODEOCEAN_TOKEN_KEY_ENV}": "abc-12345"}),
+    )
+    @patch("boto3.session.Session")
+    @patch("logging.Logger.warning")
+    def test_get_codeocean_client(
+        self, mock_log: MagicMock, mock_session: MagicMock
+    ) -> None:
+        """Tests that the codeocean client is constructed correctly."""
+
+        # Check api token pulled from env var
+        job = GenericS3UploadJob(self.args1)
+        co_client = job._get_codeocean_client()
+        expected_domain = job.configs.service_endpoints.get(
+            job.CODEOCEAN_DOMAIN_KEY
+        )
+        expected_co_client = CodeOceanClient(
+            domain=expected_domain, token="abc-12345"
+        )
+        self.assertEqual(expected_co_client.domain, co_client.domain)
+        self.assertEqual(expected_co_client.token, co_client.token)
+
+        # Check api token pulled from aws secrets
+        del os.environ[job.CODEOCEAN_TOKEN_KEY_ENV]
+        mock_session.return_value = self._mock_boto_get_secret_session(
+            f'{{"{job.CODEOCEAN_READ_WRITE_KEY}": "abc-12345"}}'
+        )
+        job2 = GenericS3UploadJob(self.args1)
+        co_client2 = job2._get_codeocean_client()
+        self.assertEqual(expected_co_client.domain, co_client2.domain)
+        self.assertEqual(expected_co_client.token, co_client2.token)
+
+        # Check warnings if api token not found
+        mock_session.return_value = self._mock_boto_get_secret_session_error()
+        job3 = GenericS3UploadJob(self.args1)
+        co_client3 = job3._get_codeocean_client()
+        mock_log.assert_called_with(
+            f"Unable to retrieve aws secret: {job.CODEOCEAN_TOKEN_KEY}"
+        )
+        self.assertIsNone(co_client3)
+
+    @patch.dict(
+        os.environ,
+        ({f"{GenericS3UploadJob.CODEOCEAN_TOKEN_KEY_ENV}": "abc-12345"}),
+    )
+    @patch.object(CodeOceanClient, "get_capsule")
+    @patch.object(CodeOceanClient, "run_capsule")
+    @patch("logging.Logger.info")
+    @patch("logging.Logger.debug")
+    @patch("logging.Logger.warning")
+    def test_trigger_capsule(
+        self,
+        mock_log_warning: MagicMock,
+        mock_log_debug: MagicMock,
+        mock_log_info: MagicMock,
+        mock_run_capsule: MagicMock,
+        mock_get_capsule: MagicMock,
+    ) -> None:
+        """Tests that the codeocean capsule is triggered correctly."""
+
+        # Test dry-run
+        mock_get_capsule.return_value = "Ran a capsule!"
+        job = GenericS3UploadJob(self.args1)
+        job.trigger_codeocean_capsule()
+        mock_get_capsule.assert_called_once()
+        mock_log_info.assert_has_calls(
+            [
+                call("Triggering capsule run."),
+                call(
+                    "Would have ran capsule: abc-123 at "
+                    "https://codeocean.acme.org"
+                ),
+            ]
+        )
+
+        # Test non dry-run
+        mock_run_capsule.return_value.json = lambda: "Success!"
+        job.configs.dry_run = False
+        job.trigger_codeocean_capsule()
+        mock_log_debug.assert_called_once_with("Run response: Success!")
+
+        # Check warning message if codeocean endpoints not configured
+        empty_args = self.args1.copy()
+        empty_args[13] = "{}"
+        job2 = GenericS3UploadJob(empty_args)
+        job2.trigger_codeocean_capsule()
+        mock_log_warning.assert_has_calls(
+            [
+                call(
+                    f"Unable to retrieve aws secret: "
+                    f"{job2.SERVICE_ENDPOINT_KEY}"
+                ),
+                call("CodeOcean endpoints are required to trigger capsule."),
+            ]
+        )
+
+    @patch.dict(
+        os.environ,
+        ({f"{GenericS3UploadJob.CODEOCEAN_TOKEN_KEY_ENV}": "abc-12345"}),
+    )
+    @patch("aind_data_transfer.jobs.s3_upload_job.upload_to_s3")
+    @patch.object(GenericS3UploadJob, "upload_subject_metadata")
+    @patch.object(GenericS3UploadJob, "upload_data_description_metadata")
+    @patch.object(GenericS3UploadJob, "trigger_codeocean_capsule")
+    def test_run_job(
+        self,
+        mock_trigger_codeocean_capsule: MagicMock,
+        mock_upload_data_description_metadata: MagicMock,
+        mock_upload_subject_metadata: MagicMock,
+        mock_upload_to_s3: MagicMock,
+    ) -> None:
+        """Tests that the run_job method triggers all the sub jobs."""
+
+        job = GenericS3UploadJob(self.args1)
+        job.run_job()
+        data_prefix = "/".join([job.s3_prefix, job.configs.modality])
+
+        mock_trigger_codeocean_capsule.assert_called_once()
+        mock_upload_data_description_metadata.assert_called_once()
+        mock_upload_subject_metadata.assert_called_once()
+        mock_upload_to_s3.assert_called_once_with(
+            directory_to_upload=job.configs.data_source,
+            s3_bucket=job.configs.s3_bucket,
+            s3_prefix=data_prefix,
+            dryrun=job.configs.dry_run,
+        )

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -135,6 +135,9 @@ class TestGenericS3UploadJob(unittest.TestCase):
             "acq_time": "13-24-01",
             "s3_region": "us-west-2",
             "service_endpoints": json.loads(self.fake_endpoints_str),
+            "capsule_parameters": {
+                "trigger_codeocean_job": {"job_type": "register_data"}
+            },
             "dry_run": True,
         }
         self.assertEqual(expected_configs_vars, vars(job.configs))
@@ -338,8 +341,10 @@ class TestGenericS3UploadJob(unittest.TestCase):
             [
                 call("Triggering capsule run."),
                 call(
-                    "Would have ran capsule: abc-123 at "
-                    "https://codeocean.acme.org"
+                    f"Would have ran capsule abc-123 at "
+                    f"https://codeocean.acme.org with parameters: "
+                    f"{[json.dumps(job.DEFAULT_CODEOCEAN_CAPSULE_PARAMETERS)]}"
+                    f"."
                 ),
             ]
         )

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -11,10 +11,10 @@ class TestProcessingMetadata(unittest.TestCase):
         acq_time = "13-24-01"
 
         expected_s3_prefix = "ecephys_12345_2020-10-10_13-24-01"
-        actual_s3_prefix = GenericS3UploadJob.create_s3_prefix(modality,
-                                                               subject_id,
-                                                               acq_date,
-                                                               acq_time)
+        actual_s3_prefix = GenericS3UploadJob._create_s3_prefix(modality,
+                                                                subject_id,
+                                                                acq_date,
+                                                                acq_time)
         self.assertEqual(expected_s3_prefix, actual_s3_prefix)
 
     def test_create_s3_prefix_error(self):
@@ -22,29 +22,29 @@ class TestProcessingMetadata(unittest.TestCase):
         subject_id = "12345"
 
         with self.assertRaises(ValueError):
-            GenericS3UploadJob.create_s3_prefix(modality,
-                                                subject_id,
+            GenericS3UploadJob._create_s3_prefix(modality,
+                                                 subject_id,
                                               "2020-13-10",  # Bad month
                                               "12-01-01")
         with self.assertRaises(ValueError):
-            GenericS3UploadJob.create_s3_prefix(modality,
-                                                subject_id,
+            GenericS3UploadJob._create_s3_prefix(modality,
+                                                 subject_id,
                                               "2020-12-32",  # Bad day
                                               "12-01-01")
         with self.assertRaises(ValueError):
-            GenericS3UploadJob.create_s3_prefix(modality,
-                                                subject_id,
+            GenericS3UploadJob._create_s3_prefix(modality,
+                                                 subject_id,
                                               "2020-12-31",
                                               "24-60-01")  # Bad hour
 
         with self.assertRaises(ValueError):
-            GenericS3UploadJob.create_s3_prefix(modality,
-                                                subject_id,
+            GenericS3UploadJob._create_s3_prefix(modality,
+                                                 subject_id,
                                               "2020-12-31",
                                               "12-60-01")  # Bad minute
         with self.assertRaises(ValueError):
-            GenericS3UploadJob.create_s3_prefix(modality,
-                                                subject_id,
+            GenericS3UploadJob._create_s3_prefix(modality,
+                                                 subject_id,
                                               "2020-12-31",
                                               "12-59-60")  # Bad second
 

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -228,7 +228,7 @@ class TestGenericS3UploadJob(unittest.TestCase):
         mock_copy_to_s3.assert_called_once_with(
             file_to_upload=tmp_file_handle.name,
             s3_bucket="some_s3_bucket",
-            s3_prefix=("ecephys_12345_2022-10-10_13-24-01/subject.json"),
+            s3_prefix="ecephys_12345_2022-10-10_13-24-01/subject.json",
             dryrun=True,
         )
 
@@ -237,28 +237,18 @@ class TestGenericS3UploadJob(unittest.TestCase):
         empty_args[13] = "{}"
         job2 = GenericS3UploadJob(empty_args)
         job2.upload_subject_metadata()
-        mock_log.assert_has_calls(
-            [
-                call(
-                    f"Unable to retrieve aws secret: "
-                    f"{job2.SERVICE_ENDPOINT_KEY}"
-                ),
-                call(
-                    "No metadata service url given. "
-                    "Not able to get subject metadata."
-                ),
-            ]
+        mock_log.assert_called_once_with(
+            "No metadata service url given. "
+            "Not able to get subject metadata."
         )
 
     @patch("aind_data_transfer.jobs.s3_upload_job.copy_to_s3")
-    @patch("logging.Logger.warning")
     @patch("tempfile.NamedTemporaryFile", new_callable=mock_open())
     @patch("boto3.session.Session")
     def test_upload_data_description_metadata(
         self,
         mock_session: MagicMock,
         mocked_tempfile: MagicMock,
-        mock_log: MagicMock,
         mock_copy_to_s3: MagicMock,
     ) -> None:
         """Tests data description is uploaded correctly."""
@@ -277,15 +267,6 @@ class TestGenericS3UploadJob(unittest.TestCase):
             dryrun=True,
         )
         tmp_file_handle.write.assert_called_once()
-
-        # Check warning message if not metadata url is found
-        empty_args = self.args1.copy()
-        empty_args[13] = "{}"
-        job2 = GenericS3UploadJob(empty_args)
-        job2.upload_data_description_metadata()
-        mock_log.assert_called_with(
-            f"Unable to retrieve aws secret: {job.SERVICE_ENDPOINT_KEY}"
-        )
 
     @patch.dict(
         os.environ,
@@ -374,14 +355,8 @@ class TestGenericS3UploadJob(unittest.TestCase):
         empty_args[13] = "{}"
         job2 = GenericS3UploadJob(empty_args)
         job2.trigger_codeocean_capsule()
-        mock_log_warning.assert_has_calls(
-            [
-                call(
-                    f"Unable to retrieve aws secret: "
-                    f"{job2.SERVICE_ENDPOINT_KEY}"
-                ),
-                call("CodeOcean endpoints are required to trigger capsule."),
-            ]
+        mock_log_warning.assert_called_once_with(
+            "CodeOcean endpoints are required to trigger capsule."
         )
 
     @patch.dict(

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -265,7 +265,7 @@ class TestGenericS3UploadJob(unittest.TestCase):
             file_to_upload=tmp_file_handle.name,
             s3_bucket="some_s3_bucket",
             s3_prefix=(
-                "ecephys_12345_2022-10-10_13-24-01/rawdatadescription.json"
+                "ecephys_12345_2022-10-10_13-24-01/data_description.json"
             ),
             dryrun=True,
         )

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -1,51 +1,146 @@
 import unittest
+from io import StringIO
+from unittest.mock import patch, Mock
+import json
+from botocore.exceptions import ClientError
 from aind_data_transfer.jobs.s3_upload_job import GenericS3UploadJob
 
 
 class TestProcessingMetadata(unittest.TestCase):
 
-    def test_create_s3_prefix(self):
-        modality = "ecephys"
-        subject_id = "12345"
-        acq_date = "2020-10-10"
-        acq_time = "13-24-01"
+    fake_endpoints_str = (
+            '{"metadata_service_url": "http://metada_service_url",'
+            '"codeocean_domain": "https://codeocean.acme.org",'
+            '"codeocean_trigger_capsule": "abc-123",'
+            '"codeocean-api-token": "some_token"}'
+        )
+    args1 = (
+        ["-d", "some_dir", "-b", "some_s3_bucket", "-s", "12345",
+         "-m", "ecephys", "-a", "2022-10-10", "-t", "13-24-01",
+         "-e", fake_endpoints_str, "--dry-run"]
+    )
 
-        expected_s3_prefix = "ecephys_12345_2020-10-10_13-24-01"
-        actual_s3_prefix = GenericS3UploadJob._create_s3_prefix(modality,
-                                                                subject_id,
-                                                                acq_date,
-                                                                acq_time)
+    def test_create_s3_prefix(self):
+        job = GenericS3UploadJob(self.args1)
+
+        expected_s3_prefix = "ecephys_12345_2022-10-10_13-24-01"
+        actual_s3_prefix = job.s3_prefix
         self.assertEqual(expected_s3_prefix, actual_s3_prefix)
 
     def test_create_s3_prefix_error(self):
-        modality = "ecephys"
-        subject_id = "12345"
+        bad_args = self.args1.copy()
 
         with self.assertRaises(ValueError):
-            GenericS3UploadJob._create_s3_prefix(modality,
-                                                 subject_id,
-                                              "2020-13-10",  # Bad month
-                                              "12-01-01")
-        with self.assertRaises(ValueError):
-            GenericS3UploadJob._create_s3_prefix(modality,
-                                                 subject_id,
-                                              "2020-12-32",  # Bad day
-                                              "12-01-01")
-        with self.assertRaises(ValueError):
-            GenericS3UploadJob._create_s3_prefix(modality,
-                                                 subject_id,
-                                              "2020-12-31",
-                                              "24-60-01")  # Bad hour
+            bad_args[9] = "2020-13-10"  # Bad Month
+            GenericS3UploadJob(bad_args).s3_prefix()
 
         with self.assertRaises(ValueError):
-            GenericS3UploadJob._create_s3_prefix(modality,
-                                                 subject_id,
-                                              "2020-12-31",
-                                              "12-60-01")  # Bad minute
+            bad_args[9] = "2020-12-32"  # Bad Day
+            GenericS3UploadJob(bad_args).s3_prefix()
+
         with self.assertRaises(ValueError):
-            GenericS3UploadJob._create_s3_prefix(modality,
-                                                 subject_id,
-                                              "2020-12-31",
-                                              "12-59-60")  # Bad second
+            bad_args[9] = "2020-12-31"
+            bad_args[11] = "24-59-01"  # Bad Hour
+            GenericS3UploadJob(bad_args).s3_prefix()
+
+        with self.assertRaises(ValueError):
+            bad_args[11] = "12-60-01"  # Bad Minute
+            GenericS3UploadJob(bad_args).s3_prefix()
+
+        with self.assertRaises(ValueError):
+            bad_args[11] = "12-59-60"  # Bad Second
+            GenericS3UploadJob(bad_args).s3_prefix()
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_load_configs(self, mock_stderr):
+        job = GenericS3UploadJob(self.args1)
+        expected_configs_vars = (
+            {"data_source": "some_dir",
+             "s3_bucket": "some_s3_bucket",
+             "subject_id": "12345",
+             "modality": "ecephys",
+             "acq_date": "2022-10-10",
+             "acq_time": "13-24-01",
+             "s3_region": "us-west-2",
+             "service_endpoints": json.loads(self.fake_endpoints_str),
+             "dry_run": True}
+        )
+        self.assertEqual(expected_configs_vars, vars(job.configs))
+
+        missing_arg = (
+            ["-d", "some_dir", "-b", "some_s3_bucket", "-s", "12345",
+             "-m", "ecephys", "-a", "2022-10-10"]
+        )
+
+        with self.assertRaises(SystemExit):
+            GenericS3UploadJob(missing_arg)
+        self.assertRegexpMatches(
+            mock_stderr.getvalue(),
+            r"the following arguments are required: -t/--acq-time"
+        )
+
+    @patch('logging.Logger.warning')
+    @patch("boto3.session.Session")
+    def test_get_endpoints(self, mock_session, mock_log):
+        job = GenericS3UploadJob(self.args1)
+        expected_endpoints1 = json.loads(self.fake_endpoints_str)
+        self.assertEqual(expected_endpoints1, job.configs.service_endpoints)
+
+        # Check job loads endpoints from s3 secrets
+        args_without_endpoints = (
+            ["-d", "some_dir", "-b", "some_s3_bucket", "-s", "12345",
+             "-m", "ecephys", "-a", "2022-10-10", "-t", "10-10-00",
+             "--dry-run"]
+        )
+        mock_session_object = Mock()
+        mock_client = Mock()
+        mock_client.get_secret_value.return_value = ({
+            'SecretString': self.fake_endpoints_str
+        })
+        mock_session_object.client.return_value = mock_client
+        mock_session.return_value = mock_session_object
+        job2 = GenericS3UploadJob(args_without_endpoints)
+        self.assertEqual(expected_endpoints1, job2.configs.service_endpoints)
+
+        # Check endpoints are empty if not in sys args or in aws
+        mock_client.get_secret_value.side_effect = Mock(
+            side_effect=ClientError(
+                error_response=({
+                    'Error': {'Code': '500', 'Message': 'Error'}
+                }),
+                operation_name=None)
+        )
+        job3 = GenericS3UploadJob(args_without_endpoints)
+        self.assertEqual({}, job3.configs.service_endpoints)
+        mock_log.assert_called_with(
+            f"Unable to retrieve aws secret: {job3.SERVICE_ENDPOINT_KEY}"
+        )
+
+    @patch('aind_data_transfer.jobs.s3_upload_job.copy_to_s3')
+    @patch('logging.Logger.warning')
+    @patch(
+        'aind_data_transfer.transformations.metadata_creation.SubjectMetadata.'
+        'ephys_job_to_subject'
+    )
+    @patch('tempfile.NamedTemporaryFile')
+    def test_upload_subject_metadata(self,
+                                     mocked_tempfile,
+                                     mocked_ephys_job_to_subject,
+                                     mock_log,
+                                     mock_copy_to_s3):
+        mocked_ephys_job_to_subject.return_value = {}
+        job = GenericS3UploadJob(self.args1)
+        job._upload_subject_metadata()
+        mock_copy_to_s3.assert_called_once()
+        mocked_tempfile.assert_called_once()
+
+        # Check warning message if not metadata url is found
+        empty_args = self.args1.copy()
+        empty_args[13] = '{}'
+        job2 = GenericS3UploadJob(empty_args)
+        job2._upload_subject_metadata()
+        mock_log.assert_called_with(
+            "No metadata service url given. Not able to get subject metadata."
+        )
 
 

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -1,0 +1,51 @@
+import unittest
+from aind_data_transfer.jobs.s3_upload_job import GenericS3UploadJob
+
+
+class TestProcessingMetadata(unittest.TestCase):
+
+    def test_create_s3_prefix(self):
+        modality = "ecephys"
+        subject_id = "12345"
+        acq_date = "2020-10-10"
+        acq_time = "13-24-01"
+
+        expected_s3_prefix = "ecephys_12345_2020-10-10_13-24-01"
+        actual_s3_prefix = GenericS3UploadJob.create_s3_prefix(modality,
+                                                               subject_id,
+                                                               acq_date,
+                                                               acq_time)
+        self.assertEqual(expected_s3_prefix, actual_s3_prefix)
+
+    def test_create_s3_prefix_error(self):
+        modality = "ecephys"
+        subject_id = "12345"
+
+        with self.assertRaises(ValueError):
+            GenericS3UploadJob.create_s3_prefix(modality,
+                                                subject_id,
+                                              "2020-13-10",  # Bad month
+                                              "12-01-01")
+        with self.assertRaises(ValueError):
+            GenericS3UploadJob.create_s3_prefix(modality,
+                                                subject_id,
+                                              "2020-12-32",  # Bad day
+                                              "12-01-01")
+        with self.assertRaises(ValueError):
+            GenericS3UploadJob.create_s3_prefix(modality,
+                                                subject_id,
+                                              "2020-12-31",
+                                              "24-60-01")  # Bad hour
+
+        with self.assertRaises(ValueError):
+            GenericS3UploadJob.create_s3_prefix(modality,
+                                                subject_id,
+                                              "2020-12-31",
+                                              "12-60-01")  # Bad minute
+        with self.assertRaises(ValueError):
+            GenericS3UploadJob.create_s3_prefix(modality,
+                                                subject_id,
+                                              "2020-12-31",
+                                              "12-59-60")  # Bad second
+
+

--- a/tests/test_metadata_creation.py
+++ b/tests/test_metadata_creation.py
@@ -232,7 +232,7 @@ class TestDataDescriptionMetadata(unittest.TestCase):
 
         """
         data_description_instance = (
-            DataDescriptionMetadata.ephys_job_to_data_description(
+            DataDescriptionMetadata.get_data_description(
                 name="ecephys_0000_2022-10-20_16-30-01"
             )
         )

--- a/tests/test_metadata_creation.py
+++ b/tests/test_metadata_creation.py
@@ -13,8 +13,8 @@ from aind_data_transfer.config_loader.ephys_configuration_loader import (
     EphysJobConfigurationLoader,
 )
 from aind_data_transfer.transformations.metadata_creation import (
-    DataDescriptionMetadata,
     ProcessingMetadata,
+    RawDataDescriptionMetadata,
     SubjectMetadata,
 )
 
@@ -232,7 +232,7 @@ class TestDataDescriptionMetadata(unittest.TestCase):
 
         """
         data_description_instance = (
-            DataDescriptionMetadata.get_data_description(
+            RawDataDescriptionMetadata.get_data_description(
                 name="ecephys_0000_2022-10-20_16-30-01"
             )
         )


### PR DESCRIPTION
Closes #126 

- Adds a basic job to upload a folder to s3, also attaches subject metadata and data_description json files.

Can be run as follows:

Required arguments
```
python -m aind_data_transfer.jobs.s3_upload_job --data-source 'path_to_data_folder' --s3-bucket 's3_bucket' --subject-id '12345' --modality 'ecephys' --acq-date '2022-12-21' --acq-time '12-00-00' 
python -m aind_data_transfer.jobs.s3_upload_job -d 'path_to_data_folder' -b 's3_bucket' -s '12345' -m 'ecephys' -a '2022-12-21' -t '12-00-00'
```

Optional aws region (defaults to us-west-2)
```
python -m aind_data_transfer.jobs.s3_upload_job ... --s3-region 'us-east-1'
python -m aind_data_transfer.jobs.s3_upload_job ... -r 'us-east-1'
```

Optional service endpoints (defaults to retrieving from AWS Secrets Manager. None if not found.)
```
python -m aind_data_transfer.jobs.s3_upload_job ... --service-endpoints '{"metadata_service_url":"http://something","codeocean_domain":"https://codeocean.acme.org","codeocean_trigger_capsule":"abc-123"}'
python -m aind_data_transfer.jobs.s3_upload_job ... -e '{"metadata_service_url":"http://something","codeocean_domain":"https://codeocean.acme.org","codeocean_trigger_capsule":"abc-123"}'
```

Optional dry run (defaults to False.) If flag is set, dry-run is set to True. It will perform the operations without actually uploading or triggering the codeocean capsule. It will check that the job can hit the endpoints correctly and give a preview of the upload/trigger results:
```
python -m aind_data_transfer.jobs.s3_upload_job ... --dry-run
```

The CodeOcean API Token can be set as an env var `CODEOCEAN_API_TOKEN`. Otherwise, it will be retrieved from AWS Secrets.
