### PR TITLE
feat: update endpoint resolver

### DIFF
--- a/tests/resources/test_metadata/processing.json
+++ b/tests/resources/test_metadata/processing.json
@@ -32,6 +32,7 @@
                 },
                 "aws_secret_names": {
                     "code_ocean_api_token_name": "secret_name_for_api_token",
+                    "video_encryption_password": "video_encryption_password",
                     "region": "us-west-2"},
                 "data": {
                     "name": "openephys"

--- a/tests/test_ephys_config_loader.py
+++ b/tests/test_ephys_config_loader.py
@@ -2,6 +2,7 @@
 import os
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from numcodecs import Blosc
 
@@ -16,8 +17,14 @@ CONFIGS_DIR = TEST_DIR / "resources" / "test_configs"
 class TestEphysJobConfigs(unittest.TestCase):
     """Tests ephys job pipeline methods"""
 
-    def test_conf_loads(self):
+    @mock.patch(
+        "aind_data_transfer.config_loader.ephys_configuration_loader."
+        "EphysJobConfigurationLoader._get_endpoints"
+    )
+    def test_conf_loads(self, mocked_get_endpoints):
         """Basic config loads test"""
+
+        mocked_get_endpoints.return_value = {"codeocean_trigger_capsule": None}
 
         raw_data_dir = (
             "tests/resources/v0.6.x_neuropixels_multiexp_multistream"
@@ -49,6 +56,7 @@ class TestEphysJobConfigs(unittest.TestCase):
             "aws_secret_names": {
                 "code_ocean_api_token_name": "secret_name_for_api_token",
                 "region": "us-west-2",
+                "video_encryption_password": "video_encryption_password",
             },
             "data": {"name": "openephys"},
             "clip_data_job": {
@@ -82,8 +90,14 @@ class TestEphysJobConfigs(unittest.TestCase):
         loaded_configs = EphysJobConfigurationLoader().load_configs(args)
         self.assertEqual(loaded_configs, expected_configs)
 
-    def test_endpoints_are_resolved(self):
+    @mock.patch(
+        "aind_data_transfer.config_loader.ephys_configuration_loader."
+        "EphysJobConfigurationLoader._get_endpoints"
+    )
+    def test_endpoints_are_resolved(self, mocked_get_endpoints):
         """Tests default endpoints are resolved correctly"""
+
+        mocked_get_endpoints.return_value = {"codeocean_trigger_capsule": None}
 
         raw_data_dir = "/some/random/folder/625463_2022-10-06_10-14-25"
         expected_configs = {

--- a/tests/test_metadata_creation.py
+++ b/tests/test_metadata_creation.py
@@ -34,15 +34,23 @@ class TestProcessingMetadata(unittest.TestCase):
 
     conf_file_path = CONFIGS_DIR / "ephys_upload_job_test_configs.yml"
     args = ["-c", str(conf_file_path)]
-    loaded_configs = EphysJobConfigurationLoader().load_configs(args)
+    # loaded_configs = EphysJobConfigurationLoader().load_configs(args)
 
-    def test_create_processing_metadata(self) -> None:
+    @mock.patch(
+        "aind_data_transfer.config_loader.ephys_configuration_loader."
+        "EphysJobConfigurationLoader._get_endpoints"
+    )
+    def test_create_processing_metadata(self, mock_get_endpoints) -> None:
         """
         Tests that the processing metadata is created correctly.
 
         Returns:
 
         """
+
+        mock_get_endpoints.return_value = {"codeocean_trigger_capsule": None}
+
+        loaded_configs = EphysJobConfigurationLoader().load_configs(self.args)
 
         start_date_time = datetime.datetime.fromisoformat(
             "2020-10-20T00:00:00.000+00:00"
@@ -54,7 +62,7 @@ class TestProcessingMetadata(unittest.TestCase):
         output_location = "some_output_location"
         code_url = "https://github.com/AllenNeuralDynamics/aind-data-transfer"
 
-        parameters = self.loaded_configs
+        parameters = loaded_configs
 
         processing_instance = ProcessingMetadata.ephys_job_to_processing(
             start_date_time=start_date_time,


### PR DESCRIPTION
Closes #151

 - Makes it so a few endpoints (such as the trigger capsule id and metadata-service url) can be pulled from a central location (aws secrets manager). Originally, they were being defined in a conf file, but that means we'd have to update that file if any of the configs get updated.
 