### PR TITLE
feat: optional behavior dir for s3_upload_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ python -m aind_data_transfer.jobs.s3_upload_job ... --service-endpoints '{"metad
 python -m aind_data_transfer.jobs.s3_upload_job ... -e '{"metadata_service_url":"http://something","codeocean_domain":"https://codeocean.acme.org","codeocean_trigger_capsule":"abc-123"}'
 ```
 
+Optional behavior directory (None if not set). This will upload files from this directory to a folder called {s3_bucket}/{s3_prefix}/behavior in s3. The uploaded video files will be encrypted.
+```
+python -m aind_data_transfer.jobs.s3_upload_job ... --behavior-dir "/home/some_folder"
+python -m aind_data_transfer.jobs.s3_upload_job ... -v "/home/some_folder"
+```
+
 Optional dry run (defaults to False.) If flag is set, dry-run is set to True. It will perform the operations without actually uploading or triggering the codeocean capsule. It will check that the job can hit the endpoints correctly and give a preview of the upload/trigger results:
 ```
 python -m aind_data_transfer.jobs.s3_upload_job ... --dry-run
@@ -111,6 +117,15 @@ The csv file should look something like:
 data-source, s3-bucket, subject-id, modality, acq-date, acq-time
 dir/data_set_1, some_bucket, 123454, ecephys, 2020-10-10, 14-10-10
 dir/data_set_2, some_bucket, 123456, ecephys, 2020-10-11, 13-10-10
+```
+
+Alternatively, you can define the behavior directories also (leave the field blank to ignore the setting. Also, it's fine if it's a subfolder of the data-source)
+
+```
+data-source, s3-bucket, subject-id, modality, acq-date, acq-time, behavior-dir
+dir/data_set_1, some_bucket, 123454, ecephys, 2020-10-10, 14-10-10, dir/data_set_1/Videos
+dir/data_set_2, some_bucket, 123456, ecephys, 2020-10-11, 13-10-10, dir/alt_dir
+dir/data_set_3, some_bucket, 123456, ecephys, 2020-10-11, 13-10-10,
 ```
 
 ## Contributing

--- a/src/aind_data_transfer/transformations/ephys_compressors.py
+++ b/src/aind_data_transfer/transformations/ephys_compressors.py
@@ -1,12 +1,8 @@
 """Module that contains the API to retrieve a Compressor for Ephys Data.
 """
-import os
 from enum import Enum
-from pathlib import Path
-from typing import Optional
 
 import numpy as np
-import pyminizip
 import spikeinterface.full as si
 import spikeinterface.preprocessing as spre
 from numcodecs import Blosc
@@ -170,60 +166,3 @@ class EphysCompressors:
                     "stream_name": read_block["stream_name"],
                 }
             )
-
-
-class VideoCompressor:
-    """Class to handle video compression and encryption."""
-
-    def __init__(
-        self, compression_level: int = 5, encryption_key: Optional[str] = None
-    ) -> None:
-        """
-        Creates a video compressor with compression level and encryption key
-        Parameters
-        ----------
-        compression_level : int
-          Integer between 1 and 9. Default is 5.
-        encryption_key : Optional[str]
-          Optional password to use. Default is None.
-        """
-        self.compression_level = compression_level
-        self.encryption_key = encryption_key
-
-    class VideoFileTypes(Enum):
-        """Enum for types of video to compress"""
-
-        MPEG_4 = ".mp4"
-        QUICKTIME_MOVIE = ".mov"
-        WINDOWSMEDIA_VIEWER = ".wmv"
-        AUDIO_VIDEO_INTERLEAVE = ".avi"
-
-    video_file_extensions = tuple([member.value for member in VideoFileTypes])
-
-    def compress_all_videos_in_dir(self, video_dir: Path) -> None:
-        """
-        Compress and optionally encrypt video files in a directory
-        Parameters
-        ----------
-        video_dir : Path
-          Directory where video files are stored.
-
-        Returns
-        -------
-        None
-
-        """
-
-        for root, dirs, files in os.walk(video_dir):
-            for file in files:
-                if file.endswith(self.video_file_extensions):
-                    raw_file_path = os.path.join(root, file)
-                    zip_file_path = os.path.join(root, file) + ".zip"
-                    pyminizip.compress(
-                        str(raw_file_path),
-                        None,
-                        str(zip_file_path),
-                        self.encryption_key,
-                        self.compression_level,
-                    )
-                    os.remove(raw_file_path)

--- a/src/aind_data_transfer/transformations/video_compressors.py
+++ b/src/aind_data_transfer/transformations/video_compressors.py
@@ -1,0 +1,63 @@
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import pyminizip
+
+
+class VideoCompressor:
+    """Class to handle video compression and encryption."""
+
+    def __init__(
+        self, compression_level: int = 5, encryption_key: Optional[str] = None
+    ) -> None:
+        """
+        Creates a video compressor with compression level and encryption key
+        Parameters
+        ----------
+        compression_level : int
+          Integer between 1 and 9. Default is 5.
+        encryption_key : Optional[str]
+          Optional password to use. Default is None.
+        """
+        self.compression_level = compression_level
+        self.encryption_key = encryption_key
+
+    class VideoFileTypes(Enum):
+        """Enum for types of video to compress"""
+
+        MPEG_4 = ".mp4"
+        QUICKTIME_MOVIE = ".mov"
+        WINDOWSMEDIA_VIEWER = ".wmv"
+        AUDIO_VIDEO_INTERLEAVE = ".avi"
+
+    video_file_extensions = tuple([member.value for member in VideoFileTypes])
+
+    def compress_all_videos_in_dir(self, video_dir: Path) -> None:
+        """
+        Compress and optionally encrypt video files in a directory
+        Parameters
+        ----------
+        video_dir : Path
+          Directory where video files are stored.
+
+        Returns
+        -------
+        None
+
+        """
+
+        for root, dirs, files in os.walk(video_dir):
+            for file in files:
+                if file.endswith(self.video_file_extensions):
+                    raw_file_path = os.path.join(root, file)
+                    zip_file_path = os.path.join(root, file) + ".zip"
+                    pyminizip.compress(
+                        str(raw_file_path),
+                        None,
+                        str(zip_file_path),
+                        self.encryption_key,
+                        self.compression_level,
+                    )
+                    os.remove(raw_file_path)

--- a/src/aind_data_transfer/util/s3_utils.py
+++ b/src/aind_data_transfer/util/s3_utils.py
@@ -32,7 +32,9 @@ def get_secret(secret_name, region_name):
     return secret
 
 
-def upload_to_s3(directory_to_upload, s3_bucket, s3_prefix, dryrun):
+def upload_to_s3(
+    directory_to_upload, s3_bucket, s3_prefix, dryrun, excluded=None
+):
     # Upload to s3
     if platform.system() == "Windows":
         shell = True
@@ -42,22 +44,14 @@ def upload_to_s3(directory_to_upload, s3_bucket, s3_prefix, dryrun):
     # TODO: Use s3transfer library instead of subprocess?
     logging.info("Uploading to s3.")
     aws_dest = f"s3://{s3_bucket}/{s3_prefix}"
+    base_command = ["aws", "s3", "sync", directory_to_upload, aws_dest]
+
+    if excluded:
+        base_command.extend(["--exclude", excluded])
     if dryrun:
-        subprocess.run(
-            [
-                "aws",
-                "s3",
-                "sync",
-                directory_to_upload,
-                aws_dest,
-                "--dryrun",
-            ],
-            shell=shell,
-        )
-    else:
-        subprocess.run(
-            ["aws", "s3", "sync", directory_to_upload, aws_dest], shell=shell
-        )
+        base_command.append("--dryrun")
+    subprocess.run(base_command, shell=shell)
+
     logging.info("Finished uploading to s3.")
 
 

--- a/src/aind_data_transfer/writers/ephys_writers.py
+++ b/src/aind_data_transfer/writers/ephys_writers.py
@@ -5,7 +5,7 @@ import shutil
 
 import numpy as np
 
-from aind_data_transfer.transformations.ephys_compressors import (
+from aind_data_transfer.transformations.video_compressors import (
     VideoCompressor,
 )
 

--- a/tests/test_compressors.py
+++ b/tests/test_compressors.py
@@ -9,10 +9,13 @@ from wavpack_numcodecs import WavPack
 from aind_data_transfer.readers.ephys_readers import EphysReaders
 from aind_data_transfer.transformations.ephys_compressors import (
     EphysCompressors,
+)
+from aind_data_transfer.transformations.imaging_compressors import (
+    ImagingCompressors,
+)
+from aind_data_transfer.transformations.video_compressors import (
     VideoCompressor,
 )
-from aind_data_transfer.transformations.imaging_compressors import \
-    ImagingCompressors
 
 TEST_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 RESOURCES_DIR = TEST_DIR / "resources"


### PR DESCRIPTION
Closes #155 

- Allows users of the generic s3 upload job to define a behavior directory so that it can be in a separate folder on upload.