### PR TITLE
Fix: xarray-multiscale overwriting chunk size with default

### DIFF
--- a/src/aind_data_transfer/transcode/ome_zarr.py
+++ b/src/aind_data_transfer/transcode/ome_zarr.py
@@ -292,7 +292,7 @@ def _compute_chunks(reader, target_size_mb):
 
 
 def _create_pyramid(
-    data: Union[NDArray, dask.array.Array], n_lvls: int
+    data: Union[NDArray, dask.array.Array], n_lvls: int, chunks: tuple
 ) -> List[Union[NDArray, dask.array.Array]]:
     """
     Create a lazy multiscale image pyramid using data as the full-resolution layer.
@@ -310,6 +310,7 @@ def _create_pyramid(
         windowed_mean,  # func
         (2,) * data.ndim,  # scale factors
         preserve_dtype=True,
+        chunks=chunks
     )[:n_lvls]
     return [arr.data for arr in pyramid]
 
@@ -331,11 +332,11 @@ def _get_or_create_pyramid(reader, n_levels, chunks):
                 f"Computing them instead..."
             )
             pyramid = _create_pyramid(
-                reader.as_dask_array(chunks=chunks), n_levels
+                reader.as_dask_array(chunks=chunks), n_levels, chunks
             )
     else:
         pyramid = _create_pyramid(
-            reader.as_dask_array(chunks=chunks), n_levels
+            reader.as_dask_array(chunks=chunks), n_levels, chunks
         )
 
     return pyramid


### PR DESCRIPTION
The latest `xarray-multiscale` release `1.1.1` makes it necessary to explicitly pass the `chunks` argument to the `multiscale` function, or it will use the default chunk size/shape of 128MB