### PR TITLE
Fix: zarr s3 write bug in dask[distributed]>=2023.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ imaging = [
     'bokeh>=2.1.1, <3.0.0',
     'gcsfs',
     'xarray-multiscale',
-    'parameterized'
+    'parameterized',
+    'zarr==2.13.3'
 ]
 full = [
     'aind-data-transfer[ephys]',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ ephys = [
 ]
 imaging = [
     'argschema',
-    'dask',
-    'distributed',
+    'dask==2022.12.1',
+    'distributed==2022.12.1',
     'dask-image',
     'bokeh>=2.1.1, <3.0.0',
     'gcsfs',


### PR DESCRIPTION
- attempting to write a zarr file to an s3 path will instead write to the current directory
- revert to `dask==2022.12.1` and `distributed==2022.12.1` and `zarr==2.13.3`, which fixes the issue