### PR TITLE
Fix s3_upload.py

### DIFF
--- a/scripts/s3_upload.py
+++ b/scripts/s3_upload.py
@@ -250,7 +250,6 @@ def main():
     bucket = args.bucket
     n_failed_uploads = -1
     trigger_code_ocean = args.trigger_code_ocean
-    capsule_id = pipeline_config["co_capsule_id"]
 
     s3_path = args.s3_path
     if s3_path is None:
@@ -310,6 +309,8 @@ def main():
         job_configs["trigger_codeocean_job"] = get_smartspim_config(
             job_configs["trigger_codeocean_job"], pipeline_config
         )
+
+        capsule_id = pipeline_config["co_capsule_id"]
 
         try:
             co_cred = CodeOceanCredentials().credentials


### PR DESCRIPTION
Fixes the following when running without a `pipeline_config` argument
```
Traceback (most recent call last):
  File "/home/svc_aind_upload/cameron.arshadi/repos/aind-data-transfer/scripts/s3_upload.py", line 338, in <module>
    main()
  File "/home/svc_aind_upload/cameron.arshadi/repos/aind-data-transfer/scripts/s3_upload.py", line 253, in main
    capsule_id = pipeline_config["co_capsule_id"]
TypeError: 'NoneType' object is not subscriptable
```