### PR TITLE
Feat: get ExASPIM metadata from aind-metadata-service

### DIFF
--- a/conf/transcode_job_configs.yml
+++ b/conf/transcode_job_configs.yml
@@ -1,13 +1,15 @@
 # Leave values blank to use defaults
 endpoints:
-  raw_data_dir: "/net/172.20.102.30/aind/exaSPIM/exaSPIM_609281_2022-11-03_13-49-18"
-  dest_data_dir: "gs://aind-msma-data"
-  metadata_schemas: "https://raw.githubusercontent.com/AllenNeuralDynamics/data_schema/main/schemas"
-  code_repo_location: "https://github.com/AllenNeuralDynamics/aind-data-transfer"
+  raw_data_dir:
+  dest_data_dir:
+  metadata_schemas:
+  metadata_service_url:
+  code_repo_location:
 jobs: # Select which jobs to run
   upload_aux_files: true
   transcode: true
   create_ng_link: true
+  create_metadata: true
 data:
   name: exaspim
 transcode_job:
@@ -15,22 +17,22 @@ transcode_job:
     compressor_name: blosc
     kwargs: {cname: "zstd", clevel: 1, shuffle: "SHUFFLE"}
   chunk_size: 64  # MB
-  chunk_shape: [1, 1, 512, 256, 256]  # remove this field if you want automatic chunking
+#  chunk_shape: [1, 1, 512, 256, 256]  # remove this field if you want automatic chunking
   resume: false  # resume processing if previous job failed
   n_levels: 8
-  exclude: ["*.tif", "*.db"]
+  exclude: []
   submit_args: {
-    nodes: 8,
-    ntasks_per_node: 8,
+    nodes: 1,
+    ntasks_per_node: 32,
     cpus_per_task: 1,
     mem_per_cpu: 3000,  # MB
-    conda_activate: "/allen/programs/aind/workgroups/msma/cameron.arshadi/miniconda3/bin/activate",
-    conda_env: "aind-data-transfer",
-    run_parent_dir: "/home/cameron.arshadi/exaSPIM-transcode-jobs/exaSPIM_609281_2022-11-03_13-49-18",
-    walltime: "48:00:00",
+    conda_activate: ~,
+    conda_env: ~,
+    run_parent_dir: ~,
+    walltime: "1-00:00:00",
     tmp_space: "8GB",  # this is per node
-    mail_user: "cameron.arshadi@alleninstitute.org",
-    queue: "aind"
+    mail_user: ~,
+    queue: ~
   }
 create_ng_link_job:
   vmin: 0

--- a/src/aind_data_transfer/jobs/transcode_job.py
+++ b/src/aind_data_transfer/jobs/transcode_job.py
@@ -13,6 +13,7 @@ from aind_data_transfer.config_loader.imaging_configuration_loader import (
 )
 from aind_data_transfer.readers.imaging_readers import ImagingReaders
 from aind_data_transfer.util.file_utils import is_cloud_url, parse_cloud_url
+from aind_data_transfer.writers.imaging_writers import ExASPIMWriter
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -186,6 +187,13 @@ def main():
             LOGGER.error(
                 f"Creating neuroglancer link failed; {output_json} was not created"
             )
+
+    if job_configs["jobs"]["create_metadata"]:
+        metadata_service_url = job_configs["endpoints"]["metadata_service_url"]
+        writer = ExASPIMWriter(data_src_dir, metadata_service_url)
+        writer.write_subject(data_src_dir)
+        writer.write_data_description(data_src_dir)
+        writer.write_procedures(data_src_dir)
 
     if job_configs["jobs"]["upload_aux_files"]:
         LOGGER.info("Uploading auxiliary data")

--- a/src/aind_data_transfer/readers/imaging_readers.py
+++ b/src/aind_data_transfer/readers/imaging_readers.py
@@ -25,10 +25,10 @@ class ImagingReaders:
         """Enum for regex patterns the source folder name should match"""
 
         exaspim_acquisition = (
-            r"exaSPIM_[A-Z0-9]+_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}"
+            r"exaSPIM_([A-Z0-9]+)_(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})"
         )
         mesospim_acquisition = (
-            r"mesoSPIM_[A-Z0-9]+_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}"
+            r"mesoSPIM_([A-Z0-9]+)_(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})"
         )
 
     @staticmethod

--- a/src/aind_data_transfer/writers/imaging_writers.py
+++ b/src/aind_data_transfer/writers/imaging_writers.py
@@ -634,7 +634,7 @@ class SmartSPIMWriter:
         return new_dataset_paths, ignored_datasets
 
 
-class ExaSPIMWriter:
+class ExASPIMWriter:
     __regexes = ImagingReaders.SourceRegexPatterns
 
     def __init__(self, dataset_path: PathLike, metadata_domain: str):
@@ -657,6 +657,11 @@ class ExaSPIMWriter:
     def __parse_dataset(self, dataset_path) -> Tuple[str, datetime]:
         """
         Parses mouse ID and acquisition date from the dataset path.
+
+        Parameters
+        ------------------------
+        dataset_path: PathLike
+            path to the top-level folder of the ExASPIM dataset
 
         Returns
         ------------------------
@@ -688,7 +693,12 @@ class ExaSPIMWriter:
 
     def write_subject(self, output: PathLike) -> None:
         """
-        Creates the data description json.
+        Creates the subject.json file.
+
+        Parameters
+        ------------------------
+        output: PathLike
+            directory to write the subject.json file
         """
         response = self.__metadata_service.get_subject(self.__mouse_id)
 
@@ -726,6 +736,14 @@ class ExaSPIMWriter:
             )
 
     def write_procedures(self, output: PathLike) -> None:
+        """
+        Creates the procedures.json file
+
+        Parameters
+        ------------------------
+        output: PathLike
+            directory to write the procedures.json file
+        """
         response = self.__metadata_service.get_procedures(self.__mouse_id)
 
         if response.status_code == 200:
@@ -739,7 +757,13 @@ class ExaSPIMWriter:
 
     def write_data_description(self, output: PathLike) -> None:
         """
-        Creates the data description json.
+        Creates the data_description.json file.
+
+        Parameters
+        ------------------------
+        output: PathLike
+            directory to write the procedures.json file
+
         """
         # Creating data description
         data_description = RawDataDescription(

--- a/src/aind_data_transfer/writers/imaging_writers.py
+++ b/src/aind_data_transfer/writers/imaging_writers.py
@@ -762,7 +762,7 @@ class ExASPIMWriter:
         Parameters
         ------------------------
         output: PathLike
-            directory to write the procedures.json file
+            directory to write the data_description.json file
 
         """
         # Creating data description

--- a/src/aind_data_transfer/writers/imaging_writers.py
+++ b/src/aind_data_transfer/writers/imaging_writers.py
@@ -6,10 +6,11 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 from aind_data_schema import Funding, RawDataDescription, Subject
+from aind_data_schema.data_description import Institution, Group, Modality
 from aind_data_schema.imaging import acquisition, tile
 from aind_metadata_service.client import AindMetadataServiceClient
 
-from aind_data_transfer.readers.imaging_readers import SmartSPIMReader
+from aind_data_transfer.readers.imaging_readers import SmartSPIMReader, ImagingReaders
 from aind_data_transfer.util import file_utils
 
 PathLike = Union[str, Path]
@@ -631,3 +632,129 @@ class SmartSPIMWriter:
                 )
 
         return new_dataset_paths, ignored_datasets
+
+
+class ExaSPIMWriter:
+    __regexes = ImagingReaders.SourceRegexPatterns
+
+    def __init__(self, dataset_path: PathLike, metadata_domain: str):
+        """
+        Class constructor.
+
+        Parameters
+        ------------------------
+        dataset_path: PathLike
+            path to the top-level folder of the ExASPIM dataset
+
+        metadata_domain: str
+            Metadata domain
+
+        """
+        self.__dataset_path = dataset_path
+        self.__mouse_id, self.__acq_date = self.__parse_dataset(dataset_path)
+        self.__metadata_service = AindMetadataServiceClient(metadata_domain)
+
+    def __parse_dataset(self, dataset_path) -> Tuple[str, datetime]:
+        """
+        Parses mouse ID and acquisition date from the dataset path.
+
+        Returns
+        ------------------------
+        Tuple
+            the mouse ID string and datetime object
+        """
+        dataset_name = Path(dataset_path).stem
+
+        m = re.match(self.__regexes.exaspim_acquisition.value, dataset_name)
+        if not m:
+            raise Exception(f"Dataset name does not follow convention: {dataset_name}")
+
+        mouse_id = m.group(1)
+
+        # creation date
+        c_year = m.group(2)
+        c_month = m.group(3)
+        c_day = m.group(4)
+        c_hour = m.group(5)
+        c_min = m.group(6)
+        c_sec = m.group(7)
+
+        date_obj = datetime.strptime(
+            f"{c_year}-{c_month}-{c_day}-{c_hour}-{c_min}-{c_sec}",
+            "%Y-%m-%d-%H-%M-%S"
+        )
+
+        return mouse_id, date_obj
+
+    def write_subject(self, output: PathLike) -> None:
+        """
+        Creates the data description json.
+        """
+        response = self.__metadata_service.get_subject(self.__mouse_id)
+
+        if response.status_code == 200:
+            data = response.json()["data"]
+
+            subject = Subject(
+                species=data["species"],
+                subject_id=data["subject_id"],
+                sex=data["sex"],
+                date_of_birth=data["date_of_birth"],
+                genotype=data["genotype"],
+                mgi_allele_ids=data["mgi_allele_ids"],
+                background_strain=data["background_strain"],
+                source=data["source"],
+                rrid=data["rrid"],
+                restrictions=data["restrictions"],
+                breeding_group=data["breeding_group"],
+                maternal_id=data["maternal_id"],
+                maternal_genotype=data["maternal_genotype"],
+                paternal_id=data["paternal_id"],
+                paternal_genotype=data["paternal_genotype"],
+                light_cycle=data["light_cycle"],
+                home_cage_enrichment=data["home_cage_enrichment"],
+                wellness_reports=data["wellness_reports"],
+                notes=data["notes"],
+            )
+
+            with open(os.path.join(output, "subject.json"), "w") as f:
+                f.write(subject.json(indent=3))
+
+        else:
+            logger.error(
+                f"Mouse {self.__mouse_id} does not have subject information - res status: {response.status_code}"
+            )
+
+    def write_procedures(self, output: PathLike) -> None:
+        response = self.__metadata_service.get_procedures(self.__mouse_id)
+
+        if response.status_code == 200:
+            # FIXME: not clear what a valid response looks like yet
+            data = response.json()["data"]
+            logger.warning(f"Procedures metadata found but parsing is not yet implemented: {data}")
+        else:
+            logger.error(
+                f"Mouse {self.__mouse_id} does not have procedures information - res status: {response.status_code}"
+            )
+
+    def write_data_description(self, output: PathLike) -> None:
+        """
+        Creates the data description json.
+        """
+        # Creating data description
+        data_description = RawDataDescription(
+            modality=Modality.EXASPIM.value,
+            subject_id=self.__mouse_id,
+            creation_date=date(
+                self.__acq_date.year, self.__acq_date.month, self.__acq_date.day
+            ),
+            creation_time=time(
+                self.__acq_date.hour, self.__acq_date.minute, self.__acq_date.second
+            ),
+            institution=Institution.AIND.value,
+            group=Group.MSMA.value,
+            funding_source=[Funding(funder=Institution.AIND.value)],
+        )
+
+        with open(os.path.join(output, "data_description.json"), "w") as f:
+            f.write(data_description.json(indent=3))


### PR DESCRIPTION
This PR adds the option to create the `subject.json` and `data_description.json` files for ExASPIM acquisitions.
I added a placeholder for writing the `procedures.json`, but the mouse ID's I tried return a 404 response code with `client.get_procedures(subject_id)`, so it is not implemented for now. 

Closes #169 