### PR TITLE
hotfix: fixes openephys job enum bug

### DIFF
--- a/src/aind_data_transfer/jobs/openephys_job.py
+++ b/src/aind_data_transfer/jobs/openephys_job.py
@@ -150,7 +150,7 @@ def run_job(args):  # noqa: C901
         code_url = job_configs["endpoints"]["code_repo_location"]
         parameters = job_configs
         processing_instance = ProcessingMetadata.from_inputs(
-            process_name=ProcessName.EPHYS_PREPROCESSING,
+            process_name=ProcessName.EPHYS_PREPROCESSING.value,
             start_date_time=start_date_time,
             end_date_time=end_date_time,
             input_location=str(input_location),


### PR DESCRIPTION
Some of the processing metadata json files look like the example below. This PR should fix things moving forward. Not sure if we want to fix the existing files in s3.
```
{
   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/processing.py",
   "schema_version": "0.1.0",
   "pipeline_version": null,
   "pipeline_url": null,
   "data_processes": [
      {
         "name": "ProcessName.EPHYS_PREPROCESSING",
         "version": "0.9.2",
         "start_date_time": "2023-03-14 23:45:20.487959+00:00",
         "end_date_time": "2023-03-14 23:46:29.097181+00:00",
...
```