### PR TITLE
Feat 188: Use spikeinterface for LSB correction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dev = [
     'Sphinx'
 ]
 ephys = [
-    'spikeinterface[full]',
-    'probeinterface>=0.2.15',
+    'spikeinterface[full]>=0.97.1',
+    'probeinterface>=0.2.16',
     'zarr',
     'wavpack-numcodecs>=0.1.3'
 ]

--- a/src/aind_data_transfer/transformations/ephys_compressors.py
+++ b/src/aind_data_transfer/transformations/ephys_compressors.py
@@ -46,68 +46,6 @@ class EphysCompressors:
             )
 
     @staticmethod
-    def _get_median_and_lsb(
-        recording,
-        disable_tqdm=False,
-        **random_chunk_kwargs,
-    ):
-        """This function estimates the channel-wise medians and the overall
-        LSB from a recording
-        Parameters
-        ----------
-        recording : si.BaseRecording
-            The input recording object
-        disable_tqdm : bool, optional
-            Disable progress bar, default is False
-        **random_chunk_kwargs: keyword arguments for
-            si.get_random_data_chunks() (chunk_size, num_chunks_per_segment)
-        Returns
-        -------
-        int
-            lsb_value
-        np.array
-            median_values
-        """
-        # gather chunks
-        chunks = si.get_random_data_chunks(
-            recording, seed=0, **random_chunk_kwargs
-        )
-
-        lsb_value = 0
-        num_channels = recording.get_num_channels()
-        dtype = recording.get_dtype()
-
-        channel_idxs = np.arange(num_channels)
-        min_values = np.zeros(num_channels, dtype=dtype)
-        median_values = np.zeros(num_channels, dtype=dtype)
-        offsets = np.zeros(num_channels, dtype=dtype)
-
-        for ch in tqdm(
-            channel_idxs, desc="Estimating channel stats", disable=disable_tqdm
-        ):
-            unique_vals = np.unique(chunks[:, ch])
-            unique_vals_abs = np.abs(unique_vals)
-            # it might happen that there is a single unique value
-            # (e.g. a channel is broken)
-            if len(unique_vals) > 1:
-                lsb_val = np.min(np.diff(unique_vals))
-            else:
-                # in this case we can't estimate the LSB for the channel
-                lsb_val = 0
-
-            min_values[ch] = np.min(unique_vals_abs)
-            median_values[ch] = np.median(chunks[:, ch]).astype(dtype)
-
-            unique_vals_m = np.unique(chunks[:, ch] - median_values[ch])
-            unique_vals_abs_m = np.abs(unique_vals_m)
-            offsets[ch] = np.min(unique_vals_abs_m)
-
-            if lsb_val > lsb_value:
-                lsb_value = lsb_val
-
-        return lsb_value, median_values
-
-    @staticmethod
     def scale_read_blocks(
         read_blocks,
         num_chunks_per_segment=100,
@@ -137,7 +75,9 @@ class EphysCompressors:
             ):
                 rec_to_compress = read_block["recording"]
             else:
-                rec_to_compress = spre.correct_lsb(read_block["recording"])
+                rec_to_compress = spre.correct_lsb(read_block["recording"], 
+                                                   num_chunks_per_segment=num_chunks_per_segment,
+                                                   chunk_size=chunk_size)
             yield (
                 {
                     "scaled_recording": rec_to_compress,

--- a/src/aind_data_transfer/transformations/ephys_compressors.py
+++ b/src/aind_data_transfer/transformations/ephys_compressors.py
@@ -137,28 +137,7 @@ class EphysCompressors:
             ):
                 rec_to_compress = read_block["recording"]
             else:
-                (
-                    lsb_value,
-                    median_values,
-                ) = EphysCompressors._get_median_and_lsb(
-                    read_block["recording"],
-                    num_chunks_per_segment=num_chunks_per_segment,
-                    chunk_size=chunk_size,
-                    disable_tqdm=disable_tqdm,
-                )
-                dtype = read_block["recording"].get_dtype()
-                rec_to_compress = spre.scale(
-                    read_block["recording"],
-                    gain=1.0,
-                    offset=-median_values,
-                    dtype=dtype,
-                )
-                rec_to_compress = spre.scale(
-                    rec_to_compress, gain=1.0 / lsb_value, dtype=dtype
-                )
-                rec_to_compress.set_channel_gains(
-                    rec_to_compress.get_channel_gains() * lsb_value
-                )
+                rec_to_compress = spre.correct_lsb(read_block["recording"])
             yield (
                 {
                     "scaled_recording": rec_to_compress,

--- a/tests/test_compressors.py
+++ b/tests/test_compressors.py
@@ -86,22 +86,6 @@ class TestEphysCompressors(unittest.TestCase):
         )
         scaled_read_block = next(scaled_read_blocks)
 
-        # The lsb value should be 1 and the median values should be 0 in the
-        # scaled neuropixel recordings.
-        lsb_value, median_values = EphysCompressors._get_median_and_lsb(
-            scaled_read_block["scaled_recording"],
-            disable_tqdm=True,
-            num_chunks_per_segment=10,
-            chunk_size=chunk_size,
-        )
-
-        expected_median_values = np.zeros(
-            shape=median_values.shape, dtype=median_values.dtype
-        )
-
-        self.assertEqual(lsb_value, 1)
-        self.assertTrue(np.array_equal(expected_median_values, median_values))
-
 
 class TestImagingCompressors(unittest.TestCase):
     def test_get_compressor(self):


### PR DESCRIPTION
fixes #188 

The LSB correction has been implemented in SpikeInterface>=0.97.1 

See implementation here: https://github.com/SpikeInterface/spikeinterface/blob/master/spikeinterface/preprocessing/correct_lsb.py

@jtyoung84 should I remove the `disable_tqdm` everywhere, since it's not used anymore?