### PR TITLE
Fix a type bug in `jobs.s3_upload_job`

### DIFF
--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -467,7 +467,7 @@ class GenericS3UploadJob:
         # Upload non-behavior data to s3
         behavior_path = None if behavior_dir is None else Path(behavior_dir)
         self.upload_raw_data_folder(
-            data_prefix=data_prefix, behavior_dir=Path(behavior_path)
+            data_prefix=data_prefix, behavior_dir=behavior_path
         )
 
         # Optionally upload the data in the metadata directory to s3


### PR DESCRIPTION
If `behavior_path` is None, `Path(behavior_path)` raises a `TypeError`.

`behavior_path` is already the correct type for `upload_raw_data_folder()`.