### PR TITLE
feat: skips jobs with errors

### DIFF
--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -157,14 +157,15 @@ class GenericS3UploadJobList:
                 one_job.run_job()
             except Exception as e:
                 logging.error(
-                    f"There was a problem processing {current_job_num} of "
-                    f"{total_jobs} with params: {one_job.job_configs.dict()}. "
-                    f"Skipping for now. Error: {e}"
+                    f"There was a problem processing job {current_job_num} of "
+                    f"{total_jobs} with data source: "
+                    f"{one_job.job_configs.data_source}. Skipping for now. "
+                    f"Error: {e}"
                 )
                 problem_jobs.append(
-                    f"There was a problem processing {current_job_num} of "
-                    f"{total_jobs} with params: {one_job.job_configs.dict()}. "
-                    f"Error: {e}"
+                    f"There was a problem processing job {current_job_num} of "
+                    f"{total_jobs} with data source: "
+                    f"{one_job.job_configs.data_source}. Error: {e}"
                 )
             logging.info(
                 f"Finished job {current_job_num} of {total_jobs} "
@@ -173,10 +174,9 @@ class GenericS3UploadJobList:
             current_job_num += 1
         logging.info("Finished all jobs!")
         if len(problem_jobs) > 0:
-            logging.error(
-                f"There were errors processing the following jobs: "
-                f"{problem_jobs}"
-            )
+            logging.error("There were errors processing the following jobs: ")
+            for problem_job in problem_jobs:
+                logging.error(problem_job)
 
 
 if __name__ == "__main__":

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -147,19 +147,36 @@ class GenericS3UploadJobList:
         total_jobs = len(self.job_list)
         current_job_num = 1
         logging.info("Starting all jobs...")
+        problem_jobs = []
         for one_job in self.job_list:
-            # TODO: Add switch on experiment type
             logging.info(
                 f"Running job {current_job_num} of {total_jobs} "
                 f"with params: {one_job.job_configs.dict()}"
             )
-            one_job.run_job()
+            try:
+                one_job.run_job()
+            except Exception as e:
+                logging.error(
+                    f"There was a problem processing {current_job_num} of "
+                    f"{total_jobs} with params: {one_job.job_configs.dict()}. "
+                    f"Skipping for now. Error: {e}"
+                )
+                problem_jobs.append(
+                    f"There was a problem processing {current_job_num} of "
+                    f"{total_jobs} with params: {one_job.job_configs.dict()}. "
+                    f"Error: {e}"
+                )
             logging.info(
                 f"Finished job {current_job_num} of {total_jobs} "
                 f"with params: {one_job.job_configs.dict()}"
             )
             current_job_num += 1
         logging.info("Finished all jobs!")
+        if len(problem_jobs) > 0:
+            logging.error(
+                f"There were errors processing the following jobs: "
+                f"{problem_jobs}"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_basic_job.py
+++ b/tests/test_basic_job.py
@@ -3,9 +3,9 @@
 import json
 import os
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
-from datetime import datetime
 
 from requests import Response
 
@@ -241,20 +241,23 @@ class TestBasicJob(unittest.TestCase):
 
         basic_job_configs = BasicUploadJobConfigs()
         basic_job = BasicJob(job_configs=basic_job_configs)
-        basic_job._compile_metadata(Path("some_dir"),
-                                    process_start_time=datetime(2023, 4, 9))
+        basic_job._compile_metadata(
+            Path("some_dir"), process_start_time=datetime(2023, 4, 9)
+        )
 
         # Test where metadata directory is defined
         basic_job_configs.metadata_dir = METADATA_DIR
         basic_job = BasicJob(job_configs=basic_job_configs)
-        basic_job._compile_metadata(Path("some_dir"),
-                                    process_start_time=datetime(2023, 4, 9))
+        basic_job._compile_metadata(
+            Path("some_dir"), process_start_time=datetime(2023, 4, 9)
+        )
 
         # Test where metadata dir forced is true
         basic_job_configs.metadata_dir_force = True
         basic_job = BasicJob(job_configs=basic_job_configs)
-        basic_job._compile_metadata(Path("some_dir"),
-                                    process_start_time=datetime(2023, 4, 9))
+        basic_job._compile_metadata(
+            Path("some_dir"), process_start_time=datetime(2023, 4, 9)
+        )
 
         mock_json_write.assert_has_calls(
             [
@@ -263,7 +266,7 @@ class TestBasicJob(unittest.TestCase):
                 call(Path("some_dir/data_description.json")),
                 call(Path("some_dir/processing.json")),
             ],
-            any_order=True
+            any_order=True,
         )
 
         mock_copyfile.assert_has_calls(
@@ -430,7 +433,7 @@ class TestBasicJob(unittest.TestCase):
         )
         mock_compile_metadata.assert_called_once_with(
             temp_dir=(Path("some_dir") / "tmp"),
-            process_start_time=datetime(2023, 4, 9)
+            process_start_time=datetime(2023, 4, 9),
         )
         mock_encrypt_behavior.assert_called_once_with(
             temp_dir=(Path("some_dir") / "tmp")

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -168,6 +168,74 @@ class TestGenericS3UploadJobList(unittest.TestCase):
         # There are three jobs defined in the csv file
         mock_run_job.assert_has_calls([call(), call(), call(), call()])
 
+    @patch("boto3.client")
+    @patch("aind_data_transfer.jobs.basic_job.BasicJob.run_job")
+    @patch("logging.error")
+    def test_errors_skipped(
+        self,
+        mock_log_error: MagicMock,
+        mock_run_job: MagicMock,
+        mock_client: MagicMock,
+    ) -> None:
+        """Tests that jobs with errors are skipped instead of terminating
+        list."""
+        mock_resp1 = {
+            "Parameter": {"Value": self.EXAMPLE_PARAM_STORE_RESPONSE}
+        }
+        mock_resp2 = {
+            "Parameter": {"Value": json.dumps({"password": "some_password"})}
+        }
+        mock_resp3 = {
+            "Parameter": {
+                "Value": json.dumps(
+                    {"CODEOCEAN_READWRITE_TOKEN": "some_token"}
+                )
+            }
+        }
+
+        mock_client.return_value.get_parameter.side_effect = [
+            mock_resp1,
+            mock_resp2,
+            mock_resp3,
+        ]
+
+        args = ["-j", str(self.PATH_TO_EXAMPLE_CSV_FILE2)]
+        mock_run_job.side_effect = [
+            None,
+            Exception("Test"),
+            None,
+            Exception("Test"),
+        ]
+        jobs = GenericS3UploadJobList(args=args)
+
+        jobs.run_job()
+        problem_jobs = [
+            f"There was a problem processing 2 of 4 with params: "
+            f"{jobs.job_list[1].job_configs.dict()}. "
+            f"Error: Test",
+            f"There was a problem processing 4 of 4 with params: "
+            f"{jobs.job_list[3].job_configs.dict()}. "
+            f"Error: Test",
+        ]
+        mock_log_error.assert_has_calls(
+            [
+                call(
+                    f"There was a problem processing 2 of 4 with params: "
+                    f"{jobs.job_list[1].job_configs.dict()}. Skipping for now."
+                    f" Error: Test"
+                ),
+                call(
+                    f"There was a problem processing 4 of 4 with params: "
+                    f"{jobs.job_list[3].job_configs.dict()}. Skipping for now."
+                    f" Error: Test"
+                ),
+                call(
+                    f"There were errors processing the following jobs: "
+                    f"{problem_jobs}"
+                ),
+            ]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_generic_upload_job.py
+++ b/tests/test_generic_upload_job.py
@@ -209,29 +209,32 @@ class TestGenericS3UploadJobList(unittest.TestCase):
         jobs = GenericS3UploadJobList(args=args)
 
         jobs.run_job()
-        problem_jobs = [
-            f"There was a problem processing 2 of 4 with params: "
-            f"{jobs.job_list[1].job_configs.dict()}. "
-            f"Error: Test",
-            f"There was a problem processing 4 of 4 with params: "
-            f"{jobs.job_list[3].job_configs.dict()}. "
-            f"Error: Test",
-        ]
         mock_log_error.assert_has_calls(
             [
                 call(
-                    f"There was a problem processing 2 of 4 with params: "
-                    f"{jobs.job_list[1].job_configs.dict()}. Skipping for now."
-                    f" Error: Test"
+                    "There was a problem processing job 2 of 4 with data "
+                    "source: "
+                    "tests/resources/v0.6.x_neuropixels_multiexp_multistream. "
+                    "Skipping for now. Error: Test"
                 ),
                 call(
-                    f"There was a problem processing 4 of 4 with params: "
-                    f"{jobs.job_list[3].job_configs.dict()}. Skipping for now."
-                    f" Error: Test"
+                    "There was a problem processing job 4 of 4 with data "
+                    "source: "
+                    "tests/resources/v0.6.x_neuropixels_multiexp_multistream. "
+                    "Skipping for now. Error: Test"
+                ),
+                call("There were errors processing the following jobs: "),
+                call(
+                    "There was a problem processing job 2 of 4 with data "
+                    "source: "
+                    "tests/resources/v0.6.x_neuropixels_multiexp_multistream. "
+                    "Error: Test"
                 ),
                 call(
-                    f"There were errors processing the following jobs: "
-                    f"{problem_jobs}"
+                    "There was a problem processing job 4 of 4 with data "
+                    "source: "
+                    "tests/resources/v0.6.x_neuropixels_multiexp_multistream. "
+                    "Error: Test"
                 ),
             ]
         )


### PR DESCRIPTION
Closes #217 

- Adds logic to skip a job in a jobs list if it has an error
- Old logic terminated all remaining jobs in the job list
- Logs an error message after all jobs are processed in case any had errors.