### PR TITLE
Feat: sort image paths during zarr conversion

### DIFF
--- a/src/aind_data_transfer/transcode/ome_zarr.py
+++ b/src/aind_data_transfer/transcode/ome_zarr.py
@@ -77,7 +77,7 @@ def write_files(
 
     all_metrics = []
 
-    for impath in image_paths:
+    for impath in sorted(image_paths):
         LOGGER.info(f"Writing tile {impath}")
 
         # Create readers, but don't construct dask array


### PR DESCRIPTION
- ensures they are processed in the same order each time, which is useful if the job needs to be resumed post-failure