### PR TITLE
Fix: shutdown and close dask client

### DIFF
--- a/scripts/write_ome_zarr.py
+++ b/scripts/write_ome_zarr.py
@@ -238,6 +238,9 @@ def main():
     df = pd.DataFrame.from_records(all_metrics)
     df.to_csv(args.metrics_file, index_label="test_number")
 
+    client.shutdown()
+    client.close()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- With dask_mpi, it is necessary to do this or the job will continue in an idle state until it hits the specified walltime