### PR TITLE
Feat: remove padding from Imaris-based arrays

### DIFF
--- a/src/aind_data_transfer/util/io_utils.py
+++ b/src/aind_data_transfer/util/io_utils.py
@@ -190,7 +190,7 @@ class ImarisReader(DataReader):
 
         Args:
             data_path: the path to the dataset
-            chunks: the chunk shape. This is currently ignored.
+            chunks: the chunk shape
 
         Returns:
             dask.array.Array
@@ -199,7 +199,7 @@ class ImarisReader(DataReader):
         lvl = self._get_res_lvl(data_path)
         real_shape_at_lvl = self._get_shape_at_lvl(lvl)
 
-        # This array is 0-padded to be divisible by 2 across all resolution levels
+        # This array is 0-padded to be divisible by the Imaris chunk size in each dimension
         a = da.from_array(self.get_dataset(data_path), chunks=chunks)
         # Crop to the "real" shape at the given resolution
         return a[:real_shape_at_lvl[0], :real_shape_at_lvl[1], :real_shape_at_lvl[2]]

--- a/src/aind_data_transfer/util/io_utils.py
+++ b/src/aind_data_transfer/util/io_utils.py
@@ -232,7 +232,7 @@ class ImarisReader(DataReader):
         Get the shape of the image
         """
         info = self.get_dataset_info()
-        return float(info.attrs["Z"].tobytes()), float(info.attrs["Y"].tobytes()), float(info.attrs["X"].tobytes())
+        return int(info.attrs["Z"].tobytes()), int(info.attrs["Y"].tobytes()), int(info.attrs["X"].tobytes())
 
     def get_chunks(self, data_path=DEFAULT_DATA_PATH) -> tuple:
         """

--- a/src/aind_data_transfer/util/io_utils.py
+++ b/src/aind_data_transfer/util/io_utils.py
@@ -232,7 +232,7 @@ class ImarisReader(DataReader):
         Get the shape of the image
         """
         info = self.get_dataset_info()
-        return float(info.attrs["Z"].tostring()), float(info.attrs["Y"].tostring()), float(info.attrs["X"].tostring())
+        return float(info.attrs["Z"].tobytes()), float(info.attrs["Y"].tobytes()), float(info.attrs["X"].tobytes())
 
     def get_chunks(self, data_path=DEFAULT_DATA_PATH) -> tuple:
         """
@@ -310,9 +310,9 @@ class ImarisReader(DataReader):
         Get the origin for the image as a [Z,Y,X] coordinate list
         """
         info = self.get_dataset_info()
-        x_min = float(info.attrs["ExtMin0"].tostring())
-        y_min = float(info.attrs["ExtMin1"].tostring())
-        z_min = float(info.attrs["ExtMin2"].tostring())
+        x_min = float(info.attrs["ExtMin0"].tobytes())
+        y_min = float(info.attrs["ExtMin1"].tobytes())
+        z_min = float(info.attrs["ExtMin2"].tobytes())
         return [z_min, y_min, x_min]
 
     def get_extent(self) -> List[float]:
@@ -320,9 +320,9 @@ class ImarisReader(DataReader):
         Get the extent for the image as a [Z,Y,X] coordinate list
         """
         info = self.get_dataset_info()
-        x_max = float(info.attrs["ExtMax0"].tostring())
-        y_max = float(info.attrs["ExtMax1"].tostring())
-        z_max = float(info.attrs["ExtMax2"].tostring())
+        x_max = float(info.attrs["ExtMax0"].tobytes())
+        y_max = float(info.attrs["ExtMax1"].tobytes())
+        z_max = float(info.attrs["ExtMax2"].tobytes())
         return [z_max, y_max, x_max]
 
     def get_voxel_size(self) -> Tuple[List[float], str]:
@@ -335,10 +335,10 @@ class ImarisReader(DataReader):
         info = self.get_dataset_info()
         extmin = self.get_origin()
         extmax = self.get_extent()
-        x = int(info.attrs["X"].tostring())
-        y = int(info.attrs["Y"].tostring())
-        z = int(info.attrs["Z"].tostring())
-        unit = info.attrs["Unit"].tostring()
+        x = int(info.attrs["X"].tobytes())
+        y = int(info.attrs["Y"].tobytes())
+        z = int(info.attrs["Z"].tobytes())
+        unit = info.attrs["Unit"].tobytes()
         voxsize = [
             (extmax[0] - extmin[0]) / z,
             (extmax[1] - extmin[1]) / y,

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -17,7 +17,7 @@ from aind_data_transfer.util.io_utils import (
 
 # TODO: make test fixtures instead of constants?
 IM_SHAPE = (64, 128, 128)
-IM_DTYPE = np.uint16
+IM_DTYPE = np.dtype("uint8")
 
 
 def _write_test_tiffs(folder, n=1):
@@ -31,14 +31,24 @@ def _write_test_tiffs(folder, n=1):
 
 
 def _write_test_h5(folder, n=1):
-    DEFAULT_DATA_PATH = "/DataSet/ResolutionLevel 0/TimePoint 0/Channel 0/Data"
     paths = []
     for i in range(n):
         a = np.ones(IM_SHAPE, dtype=IM_DTYPE)
         path = os.path.join(folder, f"data_{i}.h5")
         paths.append(path)
         with h5py.File(path, "w") as f:
-            f.create_dataset(DEFAULT_DATA_PATH, data=a, chunks=True)
+            f.create_dataset(ImarisReader.DEFAULT_DATA_PATH, data=a, chunks=True)
+            # Write origin metadata
+            dataset_info = f.create_group("DataSetInfo/Image")
+            dataset_info.attrs["X"] = np.array(
+                list(str(IM_SHAPE[2])), dtype="S"
+            )
+            dataset_info.attrs["Y"] = np.array(
+                list(str(IM_SHAPE[1])), dtype="S"
+            )
+            dataset_info.attrs["Z"] = np.array(
+                list(str(IM_SHAPE[0])), dtype="S"
+            )
     return paths
 
 
@@ -83,7 +93,7 @@ class TestTiffReader(unittest.TestCase):
         self.assertEqual(IM_DTYPE, self._reader.get_dtype())
 
     def test_get_itemsize(self):
-        self.assertEqual(2, self._reader.get_itemsize())
+        self.assertEqual(IM_DTYPE.itemsize, self._reader.get_itemsize())
 
 
 class TestHDF5Reader(unittest.TestCase):
@@ -112,13 +122,12 @@ class TestHDF5Reader(unittest.TestCase):
         self.assertTrue(np.all(a == 1))
         self.assertEqual(IM_DTYPE, a.dtype)
 
-    # FIXME: this hangs??
-    # def test_as_dask_array(self):
-    #     d = self._reader.as_dask_array()
-    #     self.assertIsInstance(d, dask.array.Array)
-    #     self.assertEqual(IM_SHAPE, d.shape)
-    #     self.assertTrue(np.all(d == 1))
-    #     self.assertEqual(IM_DTYPE, d.dtype)
+    def test_as_dask_array(self):
+        d = self._reader.as_dask_array(chunks=(32, 32, 32))
+        self.assertIsInstance(d, dask.array.Array)
+        self.assertEqual(IM_SHAPE, d.shape)
+        self.assertTrue(np.all(d == 1))
+        self.assertEqual(IM_DTYPE, d.dtype)
 
     def test_get_shape(self):
         self.assertEqual(IM_SHAPE, self._reader.get_shape())
@@ -130,7 +139,7 @@ class TestHDF5Reader(unittest.TestCase):
         self.assertTrue(all(c >= 1 for c in chunks))
 
     def test_get_itemsize(self):
-        self.assertEqual(2, self._reader.get_itemsize())
+        self.assertEqual(IM_DTYPE.itemsize, self._reader.get_itemsize())
 
     def test_get_handle(self):
         self.assertIsNotNone(self._reader.get_handle())

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -17,7 +17,7 @@ from aind_data_transfer.util.io_utils import (
 
 # TODO: make test fixtures instead of constants?
 IM_SHAPE = (64, 128, 128)
-IM_DTYPE = np.dtype("uint8")
+IM_DTYPE = np.dtype("uint16")
 
 
 def _write_test_tiffs(folder, n=1):

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -12,6 +12,7 @@ from distributed import Client
 from parameterized import parameterized
 
 from aind_data_transfer.transcode.ome_zarr import write_files, write_folder
+from aind_data_transfer.util.io_utils import ImarisReader
 
 
 def _write_test_tiffs(folder, n=4, shape=(64, 128, 128)):
@@ -21,11 +22,10 @@ def _write_test_tiffs(folder, n=4, shape=(64, 128, 128)):
 
 
 def _write_test_h5(folder, n=4, shape=(64, 128, 128)):
-    DEFAULT_DATA_PATH = "/DataSet/ResolutionLevel 0/TimePoint 0/Channel 0/Data"
     for i in range(n):
         a = np.ones(shape, dtype=np.uint16)
         with h5py.File(os.path.join(folder, f"data_{i}.h5"), "w") as f:
-            f.create_dataset(DEFAULT_DATA_PATH, data=a, chunks=True)
+            f.create_dataset(ImarisReader.DEFAULT_DATA_PATH, data=a, chunks=True)
             # Write origin metadata
             dataset_info = f.create_group("DataSetInfo/Image")
             dataset_info.attrs["ExtMin0"] = np.array(

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -37,6 +37,15 @@ def _write_test_h5(folder, n=4, shape=(64, 128, 128)):
             dataset_info.attrs["ExtMin2"] = np.array(
                 ["3", "0", "0"], dtype="S"
             )
+            dataset_info.attrs["X"] = np.array(
+                list(str(shape[2])), dtype="S"
+            )
+            dataset_info.attrs["Y"] = np.array(
+                list(str(shape[1])), dtype="S"
+            )
+            dataset_info.attrs["Z"] = np.array(
+                list(str(shape[0])), dtype="S"
+            )
 
 
 class TestOmeZarr(unittest.TestCase):


### PR DESCRIPTION
Imaris adds 0-padding to the image to make each dimension divisible by 2 across all pyramid levels.
The true size of the image is stored in the `DataSetInfo/Image` group under attributes `X`, `Y`, and `Z`.
We can crop the dask and numpy arrays to this shape before returning them to the user.