### PR TITLE
Feat: optional background subtraction during zarr conversion

### DIFF
--- a/conf/transcode_job_configs.yml
+++ b/conf/transcode_job_configs.yml
@@ -10,6 +10,7 @@ jobs: # Select which jobs to run
   transcode: true
   create_ng_link: true
   create_metadata: true
+  background_subtraction: false  # requires a background Tiff in the derivatives folder for each raw image
 data:
   name: exaspim
   subject_id:  # required

--- a/scripts/make_mips.py
+++ b/scripts/make_mips.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import tifffile
 
-from aind_data_transfer.transcode.ome_zarr import _compute_chunks
+from aind_data_transfer.transformations.ome_zarr import _compute_chunks
 from aind_data_transfer.util.dask_utils import get_client
 from aind_data_transfer.util.env_utils import find_hdf5plugin_path
 from aind_data_transfer.util.file_utils import any_hdf5, collect_filepaths

--- a/scripts/write_ome_zarr.py
+++ b/scripts/write_ome_zarr.py
@@ -12,7 +12,7 @@ from botocore.session import get_session
 from numcodecs import blosc
 
 from aind_data_transfer.gcs import create_client
-from aind_data_transfer.transcode.ome_zarr import write_files
+from aind_data_transfer.transformations.ome_zarr import write_files
 from aind_data_transfer.util.dask_utils import get_client
 from aind_data_transfer.util.env_utils import find_hdf5plugin_path
 from aind_data_transfer.util.file_utils import *
@@ -158,6 +158,12 @@ def parse_args():
         default=None,
         help='Voxel size of the dataset as a string of floats in XYZ order, e.g. "0.3,0.3,1.0"',
     )
+    parser.add_argument(
+        "--bkg_img_dir",
+        type=str,
+        default=None,
+        help="path to the background image folder. If given, background subtraction will be done for each converted image."
+    )
     args = parser.parse_args()
     return args
 
@@ -233,6 +239,7 @@ def main():
         args.chunk_shape,
         voxsize,
         opts,
+        bkg_img_dir=args.bkg_img_dir
     )
 
     df = pd.DataFrame.from_records(all_metrics)

--- a/src/aind_data_transfer/jobs/transcode_job.py
+++ b/src/aind_data_transfer/jobs/transcode_job.py
@@ -179,6 +179,7 @@ def main():
 
     zarr_out = dest_data_dir + "/" + raw_image_dir_name + ".zarr"
     if job_configs["jobs"]["transcode"]:
+        bkg_im_dir = None
         if job_configs["jobs"]["background_subtraction"]:
             bkg_im_dir = data_src_dir / "derivatives"
             if not bkg_im_dir.is_dir():

--- a/src/aind_data_transfer/transformations/flatfield_correction.py
+++ b/src/aind_data_transfer/transformations/flatfield_correction.py
@@ -1,0 +1,58 @@
+import logging
+import os
+import re
+from enum import Enum
+
+import dask.array as da
+
+logging.basicConfig(format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M")
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
+
+
+class BkgSubtraction:
+
+    class Regexes(Enum):
+        tile_xyz_pattern = r"tile_[xX]_\d{4}_[yY]_\d{4}_[zZ]_\d{4}"
+
+    @staticmethod
+    def subtract(im: da.Array, bkg_da: da.Array) -> da.Array:
+        """
+        Subtract the background image from the input image volume.
+
+        Parameters:
+            im: 3D raw image volume dask array.
+            bkg_im: 2D background image dask array.
+
+        Returns:
+            Resulting image volume after background subtraction.
+        """
+        bkg_da = da.pad(
+            bkg_da,
+            [(0, im.shape[1] - bkg_da.shape[0]), (0, im.shape[2] - bkg_da.shape[1])],
+            mode="edge"
+        )
+        return da.clip((im + 100) - bkg_da, 100, 2 ** 16 - 1) - 100
+
+    @staticmethod
+    def get_bkg_path(tile_path: str, bkg_im_dir: str) -> str:
+        """
+        Get the path to the corresponding background image from the raw tile path and background image directory.
+
+        Parameters:
+            tile_path: path to the raw image volume.
+            bkg_im_dir: path to the background image directory.
+
+        Returns:
+            the path to the background image corresponding to the raw image.
+        """
+        m = re.search(BkgSubtraction.Regexes.tile_xyz_pattern.value, tile_path)
+        if m is None:
+            raise ValueError(f"tile name does not follow convention: {tile_path}")
+        return os.path.join(bkg_im_dir, "bkg_" + m.group(0) + ".tiff")
+
+
+
+
+
+

--- a/tests/test_deinterleave.py
+++ b/tests/test_deinterleave.py
@@ -3,7 +3,7 @@ import unittest
 import dask.array as da
 import numpy as np
 
-from src.aind_data_transfer.transformations.deinterleave import Deinterleave
+from aind_data_transfer.transformations.deinterleave import Deinterleave
 
 
 def _create_interleaved_array(shape, num_channels, array_type):

--- a/tests/test_flatfield_correction.py
+++ b/tests/test_flatfield_correction.py
@@ -1,0 +1,34 @@
+import unittest
+import os
+
+import numpy as np
+import dask.array as da
+
+from aind_data_transfer.transformations.flatfield_correction import BkgSubtraction
+
+
+class TestBkgSubtraction(unittest.TestCase):
+
+    def test_subtract(self):
+        im = da.from_array(np.full((64, 64, 64), fill_value=100, dtype=int), chunks=(16, 16, 16))
+        bkg_im = da.from_array(np.full((32, 32), fill_value=50, dtype=int), chunks=(16, 16))
+        result = BkgSubtraction.subtract(im, bkg_im)
+        self.assertIsInstance(result, da.Array)
+        self.assertEqual(result.shape, im.shape)
+        self.assertEqual(result.sum().compute(), np.product(im.shape) * 50)
+
+    def test_get_bkg_path(self):
+        bkg_im_dir = "path/to/background_images/"
+
+        with self.assertRaises(ValueError):
+            BkgSubtraction.get_bkg_path("invalid_tile_path", bkg_im_dir)
+
+        # Test with a valid tile path
+        raw_tile_path = "/path/to/tiles/tile_X_0000_Y_0000_Z_0000_ch_488.ims"
+        expected_bkg_path = os.path.join(bkg_im_dir, "bkg_tile_X_0000_Y_0000_Z_0000.tiff")
+        result = BkgSubtraction.get_bkg_path(raw_tile_path, bkg_im_dir)
+        self.assertEqual(result, expected_bkg_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -11,7 +11,7 @@ import zarr
 from distributed import Client
 from parameterized import parameterized
 
-from aind_data_transfer.transcode.ome_zarr import write_files, write_folder
+from aind_data_transfer.transformations.ome_zarr import write_files, write_folder
 from aind_data_transfer.util.io_utils import ImarisReader
 
 


### PR DESCRIPTION
This PR adds optional background subtraction to the transcode job. To use it, set `background_subtraction: true` in the `transcode_job_configs.yml` file. It will look for a file named like `bkg_tile_[XYZ coordinates].tiff`, e.g., `bkg_tile_x_0000_y_0001_z_0002.tiff`  in the `derivatives/` dir for each raw tile path. It will only work for non-interleaved files.
I also moved the `ome_zarr.py` module to `transformations` and removed the `transcode` package.