### PR TITLE
fix: removes mkdir command

### DIFF
--- a/src/aind_data_transfer/jobs/basic_job.py
+++ b/src/aind_data_transfer/jobs/basic_job.py
@@ -97,9 +97,9 @@ class BasicJob:
             behavior_dir_excluded = None
 
         for modality_config in self.job_configs.modalities:
+            print(f"Starting to process {modality_config.source}")
             if not modality_config.compress_raw_data:
                 dst_dir = temp_dir / modality_config.default_output_folder_name
-                os.mkdir(dst_dir)
                 shutil.copytree(
                     modality_config.source,
                     dst_dir,
@@ -294,13 +294,19 @@ class BasicJob:
         with tempfile.TemporaryDirectory(
             dir=self.job_configs.temp_directory
         ) as td:
+            self._instance_logger.info("Checking write credentials...")
             self._test_upload(temp_dir=Path(td))
+            self._instance_logger.info("Processing raw data...")
             self._compress_raw_data(temp_dir=Path(td))
+            self._instance_logger.info("Checking for behavior directory...")
             self._encrypt_behavior_dir(temp_dir=Path(td))
+            self._instance_logger.info("Compiling metadata...")
             self._compile_metadata(
                 temp_dir=Path(td), process_start_time=process_start_time
             )
+            self._instance_logger.info("Starting s3 upload...")
             self._upload_to_s3(temp_dir=Path(td))
+            self._instance_logger.info("Initiating code ocean pipeline...")
             self._trigger_codeocean_pipeline()
 
 

--- a/tests/test_basic_job.py
+++ b/tests/test_basic_job.py
@@ -95,7 +95,8 @@ class TestBasicJob(unittest.TestCase):
         basic_job = BasicJob(job_configs=basic_job_configs)
         basic_job._compress_raw_data(temp_dir=Path("some_path"))
 
-        mock_make_dir.assert_called_once_with(Path("some_path") / "mri")
+        # The shutil copy takes care of creating the directory
+        mock_make_dir.assert_not_called()
         # With a Behavior directory defined
         basic_job.job_configs.behavior_dir = BEHAVIOR_DIR
         basic_job._compress_raw_data(temp_dir=Path("some_path"))


### PR DESCRIPTION
Closes #240 

- Removes mkdir command since it causes issues with the shutil.copytree command
- Adds additional logging to help troubleshoot problems