### PR TITLE
Fix update tests for SI==0.98.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     'Sphinx'
 ]
 ephys = [
-    'spikeinterface[full]>=0.97.1',
+    'spikeinterface[full]>=0.98.0',
     'probeinterface>=0.2.16',
     'zarr',
     'wavpack-numcodecs>=0.1.3'

--- a/tests/test_ephys_readers.py
+++ b/tests/test_ephys_readers.py
@@ -14,16 +14,20 @@ class TestEphysReaders(unittest.TestCase):
     open_ephys_dir = RESOURCES_DIR / "v0.6.x_neuropixels_multiexp_multistream"
 
     nidaq_rec_prefix = (
-        "'recording': OpenEphysBinaryRecordingExtractor: 8 channels - 1 "
-        "segments - 30.0kHz - 0.003s, 'experiment_name': 'experiment"
+        "'recording': OpenEphysBinaryRecordingExtractor: "
+        "8 channels - 30.0kHz - 1 segments - 100 samples \n"
+        "                                   0.00s (3.33 ms) - int16 dtype - 1.56 KiB, "
+        "'experiment_name': 'experiment"
     )
     nidaq_rec_suffix = (
         "'stream_name': 'Record Node 101#NI-DAQmx-103.PXIe-6341'"
     )
 
     neuropix_rec_prefix = (
-        "'recording': OpenEphysBinaryRecordingExtractor: 384 channels - 1 "
-        "segments - 30.0kHz - 0.003s, 'experiment_name': 'experiment"
+        "'recording': OpenEphysBinaryRecordingExtractor: "
+        "384 channels - 30.0kHz - 1 segments - 100 samples \n"
+        "                                   0.00s (3.33 ms) - int16 dtype - 75.00 KiB, "
+        "'experiment_name': 'experiment"
     )
     neuropix_rec_suffix = (
         "'stream_name': 'Record Node 101#Neuropix-PXI-100.Probe"


### PR DESCRIPTION
With `spikeinterface==0.98.0`, the representation of the recording has been improved to output extended info. 

This change made the `test_ephys_readers` fail, because we were checking the string equality of such prints.

This PR updates tests to match the new format and bumps up SI to >=0.98.0 in the requirements