### PR TITLE
feat: adds option to skip staging step

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ One or more modalities need to be set. The csv headers can look like:
 modality0: [CONFOCAL, DISPIM, ECEPHYS, EPHYS, EXASPIM, FIP, FMOST, HSFP, ICEPHYS, MESOSPIM, MRI, OPHYS, SMARTSPIM, SPIM]
 modality0.source: path to modality0 raw data folder
 modality0.compress_raw_data (Optional): Override default compression behavior. True if ECEPHYS, False otherwise.
+modality0.skip_staging (Optional): If modality0.compress_raw_data is False and this is True, upload directly to s3. Default is False.
 modality0.extra_configs (Optional): path to config file to override compression defaults
 modality1 (Optional): [CONFOCAL, DISPIM, ECEPHYS, EPHYS, EXASPIM, FIP, FMOST, HSFP, ICEPHYS, MESOSPIM, MRI, OPHYS, SMARTSPIM, SPIM]
 modality1.source (Optional): path to modality0 raw data folder
 modality1.compress_raw_data (Optional): Override default compression behavior. True if ECEPHYS, False otherwise.
+modality1.skip_staging (Optional): If modality1.compress_raw_data is False and this is True, upload directly to s3. Default is False.
 modality1.extra_configs (Optional): path to config file to override compression defaults
 ...
 ```
@@ -128,6 +130,7 @@ metadata_dir_force: Default is false. If true, the metadata in the metadata fold
 dry_run: Default is false. If set to true, it will perform a dry-run of the upload portion and not actually upload anything.
 force_cloud_sync: Use with caution. If set to true, it will sync the local raw data to the cloud even if the cloud folder already exists.
 compress_raw_data: Override all compress_raw_data defaults and set them to True.
+skip_staging: For each modality, copy uncompressed data directly to s3.
 ```
 
 After creating the csv file, you can run through the jobs with

--- a/src/aind_data_transfer/config_loader/base_config.py
+++ b/src/aind_data_transfer/config_loader/base_config.py
@@ -146,6 +146,11 @@ class ModalityConfigs(BaseSettings):
         description="Location of additional configuration file",
         title="Extra Configs",
     )
+    skip_staging: bool = Field(
+        default=False,
+        description="Upload uncompressed directly without staging",
+        title="Skip Staging",
+    )
 
     @property
     def number_id(self):

--- a/src/aind_data_transfer/jobs/basic_job.py
+++ b/src/aind_data_transfer/jobs/basic_job.py
@@ -105,6 +105,8 @@ class BasicJob:
             behavior_dir_excluded = None
 
         for modality_config in self.job_configs.modalities:
+            print(self.job_configs)
+            print(modality_config)
             self._instance_logger.info(
                 f"Starting to process {modality_config.source}"
             )

--- a/src/aind_data_transfer/jobs/basic_job.py
+++ b/src/aind_data_transfer/jobs/basic_job.py
@@ -105,8 +105,6 @@ class BasicJob:
             behavior_dir_excluded = None
 
         for modality_config in self.job_configs.modalities:
-            print(self.job_configs)
-            print(modality_config)
             self._instance_logger.info(
                 f"Starting to process {modality_config.source}"
             )

--- a/src/aind_data_transfer/jobs/s3_upload_job.py
+++ b/src/aind_data_transfer/jobs/s3_upload_job.py
@@ -178,10 +178,14 @@ class GenericS3UploadJobList:
             and cleaned_row.get("skip_staging") is not None
         ):
             skip_staging = cleaned_row.get("skip_staging")
-        elif source is not None and modality_key != "modality":
+        elif (
+            source is not None
+            and modality_key != "modality"
+            and cleaned_row.get(f"{modality_key}.skip_staging") is not None
+        ):
             skip_staging = cleaned_row.get(f"{modality_key}.skip_staging")
         else:
-            skip_staging = False
+            skip_staging = cleaned_row.get("skip_staging")
 
         skip_staging = False if skip_staging is None else skip_staging
 
@@ -251,7 +255,6 @@ class GenericS3UploadJobList:
                 f"header: {modality_keys}"
             )
         for modality_key in modality_keys:
-            # modality = cleaned_row[modality_key]
             modality_configs = self._map_row_and_key_to_modality_config(
                 modality_key=modality_key,
                 cleaned_row=cleaned_row,
@@ -317,7 +320,6 @@ class GenericS3UploadJobList:
                         cleaned_row.update(job_endpoints)
                         param_store_name = cleaned_row["aws_param_store_name"]
                     del cleaned_row["aws_param_store_name"]
-
                 self._parse_modality_configs_from_row(cleaned_row=cleaned_row)
 
                 configs_from_row = BasicUploadJobConfigs(**cleaned_row)

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -540,10 +540,69 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             ExperimentType.SMARTSPIM, basic_job_configs.experiment_type
         )
         self.assertEqual(
+            [ModalityConfigs(modality=Modality.OPHYS, source=DATA_DIR)],
+            basic_job_configs.modalities,
+        )
+        self.assertEqual("12345", basic_job_configs.subject_id)
+        self.assertEqual(
+            date.fromisoformat("2022-10-10"),
+            basic_job_configs.acq_date,
+        )
+        self.assertEqual(
+            time.fromisoformat("13:24:01"),
+            basic_job_configs.acq_time,
+        )
+        self.assertEqual(
+            "SmartSPIM_12345_2022-10-10_13-24-01", basic_job_configs.s3_prefix
+        )
+
+    def test_skip_staging(self):
+        """Tests that the required configs can be set from a json string"""
+        modalities = (
+            f'[{{"modality":"OPHYS","source":"{str(DATA_DIR)}",'
+            f'"skip_staging":"true"}}]'
+        )
+        json_arg_string = (
+            f'{{"s3_bucket": "some_bucket", '
+            f'"subject_id": "12345", '
+            f'"experiment_type": "SmartSPIM", '
+            f'"modalities": {modalities}, '
+            f'"acq_date": "2022-10-10", '
+            f'"acq_time": "13-24-01", '
+            f'"codeocean_domain": "some_domain", '
+            f'"codeocean_trigger_capsule_id": "some_capsule_id", '
+            f'"metadata_service_domain": "some_ms_domain", '
+            f'"aind_data_transfer_repo_location": "some_dtr_location", '
+            f'"video_encryption_password": "some_password", '
+            f'"codeocean_api_token": "some_token"}}'
+        )
+        test_args = ["--json-args", json_arg_string]
+        basic_job_configs = BasicUploadJobConfigs.from_json_args(test_args)
+        self.assertEqual("some_domain", basic_job_configs.codeocean_domain)
+        self.assertEqual(
+            "some_capsule_id", basic_job_configs.codeocean_trigger_capsule_id
+        )
+        self.assertEqual(
+            "some_ms_domain", basic_job_configs.metadata_service_domain
+        )
+        self.assertEqual(
+            "some_dtr_location",
+            basic_job_configs.aind_data_transfer_repo_location,
+        )
+        self.assertEqual(
+            "some_password",
+            basic_job_configs.video_encryption_password.get_secret_value(),
+        )
+        self.assertEqual("some_bucket", basic_job_configs.s3_bucket)
+        self.assertEqual(
+            ExperimentType.SMARTSPIM, basic_job_configs.experiment_type
+        )
+        self.assertEqual(
             [
                 ModalityConfigs(
                     modality=Modality.OPHYS,
-                    source=DATA_DIR
+                    source=DATA_DIR,
+                    skip_staging=True,
                 )
             ],
             basic_job_configs.modalities,


### PR DESCRIPTION
Closes #250 

- Adds option to skip copying uncompressed data to staging directory
- For example, 
```
python -m aind_data_transfer.jobs.s3_upload_job --jobs-csv-file "jobs_list.csv" --dry-run --skip-staging
```
or
```
python -m aind_data_transfer.jobs.s3_upload_job --jobs-csv-file "jobs_list.csv" --skip-staging
```
will upload the data directly to s3. This is currently ignored if the compress_data flag is true.