### PR TITLE
fix: stringifies dirs in aws upload subprocess

### DIFF
--- a/src/aind_data_transfer/util/s3_utils.py
+++ b/src/aind_data_transfer/util/s3_utils.py
@@ -49,12 +49,12 @@ def upload_to_s3(
     # TODO: Use s3transfer library instead of subprocess?
     logging.info("Uploading to s3.")
     aws_dest = f"s3://{s3_bucket}/{s3_prefix}"
-    base_command = ["aws", "s3", "sync", directory_to_upload, aws_dest]
+    base_command = ["aws", "s3", "sync", str(directory_to_upload), aws_dest]
 
     if excluded:
-        base_command.extend(["--exclude", excluded])
+        base_command.extend(["--exclude", str(excluded)])
     if included:
-        base_command.extend(["--include", included])
+        base_command.extend(["--include", str(included)])
     if dryrun:
         base_command.append("--dryrun")
     subprocess.run(base_command, shell=shell, check=True)
@@ -78,7 +78,7 @@ def copy_to_s3(file_to_upload, s3_bucket, s3_prefix, dryrun):
                 "aws",
                 "s3",
                 "cp",
-                file_to_upload,
+                str(file_to_upload),
                 aws_dest,
                 "--dryrun",
             ],
@@ -87,7 +87,7 @@ def copy_to_s3(file_to_upload, s3_bucket, s3_prefix, dryrun):
         )
     else:
         subprocess.run(
-            ["aws", "s3", "cp", file_to_upload, aws_dest],
+            ["aws", "s3", "cp", str(file_to_upload), aws_dest],
             shell=shell,
             check=True,
         )


### PR DESCRIPTION
- Fixes a bug where the s3 upload command wasn't converting paths to strings.
- This explicitly stringifies the input directory when it's passed into the shell command