### PR TITLE
Feat: improve scalability and performance of OME-Zarr writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -43,10 +43,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Pull latest changes
         run: git pull origin main
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools wheel twine build

--- a/conf/dask/dask-config.yaml
+++ b/conf/dask/dask-config.yaml
@@ -9,7 +9,7 @@ distributed:
       tcp: 30s
   nanny:
     pre-spawn-environ:
-      MALLOC_TRIM_THRESHOLD_: 0
+      MALLOC_TRIM_THRESHOLD_: 65536
       OMP_NUM_THREADS: 1
       MKL_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aind-data-transfer"
 description = "Services for compression and transfer of aind-data to the cloud"
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,13 @@ ephys = [
 ]
 imaging = [
     'argschema',
-    'dask==2022.12.1',
-    'distributed==2022.12.1',
-    'dask-image',
-    'bokeh>=2.1.1, <3.0.0',
+    'dask==2023.6.0',
+    'distributed==2023.6.0',
+    'bokeh!=3.0.*,>=2.4.2',
     'gcsfs',
     'xarray-multiscale',
     'parameterized',
-    'zarr==2.14.2',
+    'zarr==2.15.0',
     'ome-zarr==0.7.1',
     'chardet==5.1.0'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,14 @@ ephys = [
 ]
 imaging = [
     'argschema',
-    'dask==2023.6.0',
-    'distributed==2023.6.0',
+    'dask==2023.7.1',
+    'distributed==2023.7.1',
     'bokeh!=3.0.*,>=2.4.2',
     'gcsfs',
     'xarray-multiscale',
     'parameterized',
-    'zarr==2.15.0',
-    'ome-zarr==0.7.1',
+    'zarr==2.16.0',
+    'ome-zarr==0.8.0',
     'chardet==5.1.0'
 ]
 full = [

--- a/scripts/write_ome_zarr.py
+++ b/scripts/write_ome_zarr.py
@@ -122,8 +122,8 @@ def parse_args():
     )
     parser.add_argument(
         "--scale_factor",
-        type=float,
-        default=2.0,
+        type=int,
+        default=2,
         help="scale factor for downsampling",
     )
     parser.add_argument(

--- a/scripts/write_ome_zarr.py
+++ b/scripts/write_ome_zarr.py
@@ -24,20 +24,6 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
 
-def get_blosc_codec(cname, clevel):
-    opts = {
-        "compressor": blosc.Blosc(
-            cname=cname, clevel=clevel, shuffle=blosc.SHUFFLE
-        ),
-        "params": {
-            "shuffle": blosc.SHUFFLE,
-            "level": clevel,
-            "name": f"blosc-{cname}",
-        },
-    }
-    return opts
-
-
 def output_valid(output: Union[str, os.PathLike]) -> bool:
     """
     Check if the output path is valid. If the path is a cloud storage location,
@@ -195,8 +181,6 @@ def main():
         "env": {
             "HDF5_PLUGIN_PATH": find_hdf5plugin_path(),
             "HDF5_USE_FILE_LOCKING": "FALSE",
-            "OMP_NUM_THREADS": "1",
-            "MALLOC_TRIM_THRESHOLD_": "0",
         }
     }
     client, _ = get_client(args.deployment, worker_options=worker_options)
@@ -227,7 +211,7 @@ def main():
 
     overwrite = not args.resume
 
-    opts = get_blosc_codec(args.codec, args.clevel)
+    compressor = blosc.Blosc(args.codec, args.clevel, shuffle=blosc.SHUFFLE)
 
     all_metrics = write_files(
         images,
@@ -238,7 +222,7 @@ def main():
         args.chunk_size,
         args.chunk_shape,
         voxsize,
-        opts,
+        compressor,
         bkg_img_dir=args.bkg_img_dir
     )
 

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -876,8 +876,8 @@ def downsample_and_store(
 
     Parameters
     ----------
-    first_mipmap : da.Array
-        The input Dask array.
+    arr : da.Array
+        The full-resolution Dask array.
     group : zarr.Group
         The output Zarr group.
     n_lvls : int

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -4,15 +4,13 @@ import time
 from pathlib import Path
 from typing import List, Optional, Dict, cast
 
-import dask
-import dask.array
 import tifffile
 import zarr
-from distributed import wait
-from numpy.typing import NDArray
+from numcodecs.abc import Codec
+from numpy.typing import ArrayLike, NDArray
 from ome_zarr.format import CurrentFormat
 from ome_zarr.io import parse_url
-from ome_zarr.writer import write_multiscale
+from ome_zarr.writer import write_multiscales_metadata
 from xarray_multiscale import multiscale
 from xarray_multiscale.reducers import windowed_mean
 
@@ -21,11 +19,17 @@ from aind_data_transfer.util.file_utils import collect_filepaths
 from aind_data_transfer.util.io_utils import (
     DataReaderFactory,
     ImarisReader,
-    MissingDatasetError,
-    DataReader
+    DataReader,
+    BlockedArrayWriter,
 )
-from aind_data_transfer.transformations.deinterleave import ChannelParser, Deinterleave
-from aind_data_transfer.transformations.flatfield_correction import BkgSubtraction
+from aind_data_transfer.transformations.deinterleave import (
+    ChannelParser,
+    Deinterleave,
+)
+from aind_data_transfer.transformations.flatfield_correction import (
+    BkgSubtraction,
+)
+
 
 logging.basicConfig(format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M")
 LOGGER = logging.getLogger(__name__)
@@ -41,8 +45,8 @@ def write_files(
     chunk_size: float = 64,  # MB
     chunk_shape: tuple = None,
     voxel_size: tuple = None,
-    storage_options: dict = None,
-    bkg_img_dir: Optional[str] = None
+    compressor: Codec = None,
+    bkg_img_dir: Optional[str] = None,
 ) -> list:
     """
     Write each image as a separate group to a Zarr store.
@@ -75,9 +79,6 @@ def write_files(
     if not image_paths:
         LOGGER.warning("No images found. Exiting.")
         return []
-
-    if storage_options is None:
-        storage_options = {}
 
     store = parse_url(output, mode="w").store
     root_group = zarr.group(store=store)
@@ -126,12 +127,12 @@ def write_files(
                     output,
                     channel_names,
                     n_levels,
-                    scale_factor,
+                    (scale_factor,) * len(reader.get_shape()),
                     origin,
                     voxel_size,
                     chunks,
                     overwrite,
-                    storage_options
+                    compressor,
                 )
                 all_metrics.append(tile_metrics)
             else:
@@ -140,13 +141,13 @@ def write_files(
                     root_group,
                     output,
                     n_levels,
-                    scale_factor,
+                    (scale_factor,) * len(reader.get_shape()),
                     origin,
                     voxel_size,
                     chunks,
                     overwrite,
-                    storage_options,
-                    bkg_img_dir=bkg_img_dir
+                    compressor,
+                    bkg_img_dir=bkg_img_dir,
                 )
                 all_metrics.append(tile_metrics)
 
@@ -154,29 +155,29 @@ def write_files(
 
 
 def _store_file(
-        reader: DataReader,
-        root_group: zarr.Group,
-        output: str,
-        n_levels: int,
-        scale_factor: int,
-        origin: list,
-        voxel_size: tuple,
-        chunks: tuple,
-        overwrite: bool,
-        storage_options: dict,
-        bkg_img_dir: Optional[str] = None
+    reader: DataReader,
+    root_group: zarr.Group,
+    output: str,
+    n_levels: int,
+    scale_factors: tuple,
+    origin: list,
+    voxel_size: tuple,
+    chunks: tuple,
+    overwrite: bool,
+    compressor: Codec = None,
+    bkg_img_dir: Optional[str] = None,
 ) -> dict:
     """
     Write an image to an existing Zarr store
 
     Args:
         reader: the reader for the image
-        writer: the OmeZarrWriter instance
-        output: the location of the output Zarr store (filesystem, s3, gs)
+        root_group: the top-level zarr Group
+        output: the uri of the output Zarr store (filesystem, s3, gs)
         n_levels: number of downsampling levels
-        scale_factor: scale factor for downsampling in X, Y and Z
+        scale_factors: scale factors for downsampling in Z,Y,X
         origin: the tile origin coordinates in ZYX order
-        physical_pixel_sizes: the voxel size of the image
+        voxel_size: the voxel size of the image
         chunks: the chunk shape
         overwrite: whether to overwrite image groups that already exist
         storage_options: a dictionary of options to pass to the Zarr storage backend, e.g., "compressor"
@@ -189,74 +190,110 @@ def _store_file(
     LOGGER.info(f"new tile name: {tile_name}")
 
     tile_metrics = {"chunks": chunks, "tile": tile_name}
-    try:
-        tile_metrics.update(storage_options["params"])
-    except KeyError:
-        LOGGER.warning("compression parameters will not be logged")
 
     if not overwrite and _tile_exists(output, tile_name, n_levels):
         LOGGER.info(f"Skipping tile {tile_name}, already exists.")
         return tile_metrics
 
-    # Get the chunk dimensions that exist in the original, un-padded image
-    reader_chunks = chunks[len(chunks) - len(reader.get_shape()):]
-
-    pyramid = _get_or_create_pyramid(reader, n_levels, reader_chunks)
-
-    if bkg_img_dir is not None:
-        bkg_img_pyramid = _create_pyramid(
-            tifffile.imread(BkgSubtraction.get_bkg_path(reader.get_filepath(), bkg_img_dir)),
-            n_levels
-        )
-        for i in range(len(bkg_img_pyramid)):
-            pyramid[i] = BkgSubtraction.subtract(
-                pyramid[i],
-                da.from_array(bkg_img_pyramid[i], chunks=(256, 256))
-            )
-
-    pyramid = [ensure_array_5d(arr) for arr in pyramid]
-
-    LOGGER.info(f"{pyramid[0]}")
-
-    ome_json = _build_ome(
-        pyramid[0].shape,
-        tile_name,
-        channel_names=None,
-        channel_colors=None,
-        channel_minmax=None
-    )
-    axes_5d = _get_axes_5d()
-    transforms, chunk_opts = _compute_scales(
-        len(pyramid),
-        (scale_factor,) * 3,
-        voxel_size,
-        chunks,
-        pyramid[0].shape,
-        origin,
-    )
-    for opt in chunk_opts:
-        opt.update(storage_options)
+    reader_chunks = chunks[len(chunks) - len(reader.get_shape()) :]
 
     group = root_group.create_group(tile_name, overwrite=True)
-    group.attrs["omero"] = ome_json
 
-    LOGGER.info("Starting write...")
-    t0 = time.time()
-    jobs = write_multiscale(
-        pyramid,
-        group=group,
-        fmt=CurrentFormat(),
-        axes=axes_5d,
-        coordinate_transformations=transforms,
-        storage_options=chunk_opts,
-        name=None,
-        compute=False,
-    )
-    if jobs:
-        LOGGER.info("Computing dask arrays...")
-        arrs = dask.persist(*jobs)
-        wait(arrs)
-    write_time = time.time() - t0
+    if isinstance(reader, ImarisReader) and reader.n_levels >= n_levels:
+        # Use the pre-computed pyramid in the Imaris file
+        pyramid = reader.get_dask_pyramid(
+            n_levels,
+            timepoint=0,
+            channel=0,
+            # Use only the dimensions that exist in the base image.
+            chunks=reader_chunks,
+        )
+
+        if bkg_img_dir is not None:
+            bkg_img_pyramid = create_pyramid(
+                tifffile.imread(
+                    BkgSubtraction.get_bkg_path(
+                        reader.get_filepath(), bkg_img_dir
+                    )
+                ),
+                n_levels,
+                scale_factors[1:],
+            )
+            for i in range(len(bkg_img_pyramid)):
+                pyramid[i] = BkgSubtraction.subtract(
+                    pyramid[i],
+                    da.from_array(bkg_img_pyramid[i], chunks=(128, 128)),
+                )
+
+        # The background subtraction can change the chunks,
+        # so rechunk before storing
+        pyramid = [ensure_array_5d(arr).rechunk(chunks) for arr in pyramid]
+
+        block_shape = ensure_shape_5d(
+            BlockedArrayWriter.get_block_shape(pyramid[0])
+        )
+        LOGGER.info(f"block shape: {block_shape}")
+
+        write_ome_ngff_metadata(
+            group,
+            pyramid[0],
+            tile_name,
+            n_levels,
+            scale_factors,
+            voxel_size,
+            origin,
+        )
+
+        t0 = time.time()
+        for arr_index, arr in enumerate(pyramid):
+            store_array(arr, group, str(arr_index), block_shape, compressor)
+        write_time = time.time() - t0
+
+    else:
+        # Downsample from scratch
+        arr = reader.as_dask_array(chunks=reader_chunks)
+
+        if bkg_img_dir is not None:
+            bkg_img = (
+                tifffile.imread(
+                    BkgSubtraction.get_bkg_path(
+                        reader.get_filepath(), bkg_img_dir
+                    )
+                ),
+            )
+            arr = BkgSubtraction.subtract(
+                arr, da.from_array(bkg_img, chunks=(128, 128))
+            )
+
+        arr = ensure_array_5d(arr)
+        # The background subtraction can change the chunks,
+        # so rechunk before storing
+        arr = arr.rechunk(chunks)
+
+        LOGGER.info(f"input array: {arr}")
+        LOGGER.info(f"input array size: {arr.nbytes / 2 ** 20} MiB")
+
+        block_shape = ensure_shape_5d(BlockedArrayWriter.get_block_shape(arr))
+        LOGGER.info(f"block shape: {block_shape}")
+
+        write_ome_ngff_metadata(
+            group,
+            arr,
+            tile_name,
+            n_levels,
+            scale_factors,
+            voxel_size,
+            origin,
+        )
+
+        scale_factors = ensure_shape_5d(scale_factors)
+
+        t0 = time.time()
+        store_array(arr, group, "0", block_shape, compressor)
+        pyramid = downsample_and_store(
+            arr, group, n_levels, scale_factors, block_shape, compressor
+        )
+        write_time = time.time() - t0
 
     _populate_metrics(
         tile_metrics,
@@ -278,17 +315,17 @@ def _store_file(
 
 
 def _store_interleaved_file(
-        reader: DataReader,
-        root_group: zarr.Group,
-        output: str,
-        channel_names: list,
-        n_levels: int,
-        scale_factor: int,
-        origin: list,
-        voxel_size: tuple,
-        chunks: tuple,
-        overwrite: bool,
-        storage_options: dict,
+    reader: DataReader,
+    root_group: zarr.Group,
+    output: str,
+    channel_names: list,
+    n_levels: int,
+    scale_factors: tuple,
+    origin: list,
+    voxel_size: tuple,
+    chunks: tuple,
+    overwrite: bool,
+    compressor: Codec = None,
 ) -> dict:
     """
     Write an image to an existing Zarr store
@@ -309,17 +346,11 @@ def _store_interleaved_file(
         A list of metrics for each converted image
     """
     tile_metrics = {"chunks": chunks}
-    try:
-        tile_metrics.update(storage_options["params"])
-    except KeyError:
-        LOGGER.warning("compression parameters will not be logged")
 
     # Get the chunk dimensions that exist in the original, un-padded image
-    reader_chunks = chunks[len(chunks) - len(reader.get_shape()):]
+    reader_chunks = chunks[len(chunks) - len(reader.get_shape()) :]
     channels = Deinterleave.deinterleave(
-        reader.as_dask_array(reader_chunks),
-        len(channel_names),
-        axis=0
+        reader.as_dask_array(reader_chunks), len(channel_names), axis=0
     )
     for channel_idx, channel in enumerate(channels):
         tile_prefix = ChannelParser.parse_tile_xyz_loc(reader.get_filepath())
@@ -330,62 +361,56 @@ def _store_interleaved_file(
             LOGGER.info(f"Skipping tile {tile_name}, already exists.")
             continue
 
+        group = root_group.create_group(tile_name, overwrite=True)
+
         tile_metrics["tile"] = tile_name
 
-        channel_pyramid = _create_pyramid(channel, n_levels, chunks=reader_chunks)
-        channel_pyramid = [ensure_array_5d(arr) for arr in channel_pyramid]
+        channel = ensure_array_5d(channel)
+        # Deinterleaving divides the chunk size in Z by the number
+        # of channels, so rechunk back to the desired shape
+        channel = channel.rechunk(chunks)
 
-        LOGGER.info(f"{channel_pyramid[0]}")
+        LOGGER.info(f"input array: {channel}")
+        LOGGER.info(f"input array size: {channel.nbytes / 2 ** 20} MiB")
 
-        ome_json = _build_ome(
-            channel_pyramid[0].shape,
-            tile_name,
-            channel_names=None,
-            channel_colors=None,
-            channel_minmax=None
+        block_shape = ensure_shape_5d(
+            BlockedArrayWriter.get_block_shape(channel)
         )
-        axes_5d = _get_axes_5d()
-        transforms, chunk_opts = _compute_scales(
-            len(channel_pyramid),
-            (scale_factor,) * 3,
+        LOGGER.info(f"block shape: {block_shape}")
+
+        scale_factors = ensure_shape_5d(scale_factors)
+
+        write_ome_ngff_metadata(
+            group,
+            channel,
+            tile_name,
+            n_levels,
+            scale_factors[2:],
             voxel_size,
-            chunks,
-            channel_pyramid[0].shape,
             origin,
         )
-        for opt in chunk_opts:
-            opt.update(storage_options)
 
-        group = root_group.create_group(tile_name, overwrite=True)
-        group.attrs["omero"] = ome_json
-
-        LOGGER.info("Starting write...")
         t0 = time.time()
-        jobs = write_multiscale(
-            channel_pyramid,
-            group=group,
-            fmt=CurrentFormat(),
-            axes=axes_5d,
-            coordinate_transformations=transforms,
-            storage_options=chunk_opts,
-            name=None,
-            compute=False,
+        store_array(channel, group, "0", block_shape, compressor)
+        pyramid = downsample_and_store(
+            channel,
+            group,
+            n_levels,
+            scale_factors,
+            block_shape,
+            compressor,
         )
-        if jobs:
-            LOGGER.info("Computing dask arrays...")
-            arrs = dask.persist(*jobs)
-            wait(arrs)
         write_time = time.time() - t0
 
         _populate_metrics(
             tile_metrics,
             tile_name,
             output,
-            _get_bytes(channel_pyramid),
+            _get_bytes(pyramid),
             write_time,
             n_levels,
-            channel_pyramid[0].shape,
-            channel_pyramid[0].dtype,
+            pyramid[0].shape,
+            pyramid[0].dtype,
         )
 
         LOGGER.info(
@@ -406,9 +431,9 @@ def write_folder(
     chunk_shape: tuple = None,
     voxel_size: tuple = None,
     exclude: list = None,
-    storage_options: dict = None,
+    compressor: Codec = None,
     recursive: bool = False,
-    bkg_img_dir: Optional[str] = None
+    bkg_img_dir: Optional[str] = None,
 ) -> list:
     """
     Write each image in the input directory as a separate group
@@ -458,8 +483,8 @@ def write_folder(
         chunk_size,
         chunk_shape,
         voxel_size,
-        storage_options,
-        bkg_img_dir=bkg_img_dir
+        compressor,
+        bkg_img_dir=bkg_img_dir,
     )
 
 
@@ -487,11 +512,9 @@ def _tile_exists(zarr_path, tile_name, n_levels):
 
 def _compute_chunks(reader, target_size_mb):
     target_size_bytes = target_size_mb * 1024 * 1024
-    padded_chunks = ensure_shape_5d(reader.get_chunks())
-    padded_shape = ensure_shape_5d(reader.get_shape())
-    spatial_chunks = padded_chunks[2:]
-    spatial_shape = padded_shape[2:]
-    LOGGER.info(f"Using multiple of base chunk size: {padded_chunks}")
+    spatial_chunks = reader.get_chunks()[-3:]
+    spatial_shape = reader.get_shape()[-3:]
+    LOGGER.info(f"Using multiple of base chunk size: {spatial_chunks}")
     if spatial_chunks[1:] == spatial_shape[1:]:
         LOGGER.info(
             "chunks and shape have same XY dimensions, "
@@ -508,59 +531,7 @@ def _compute_chunks(reader, target_size_mb):
             reader.get_itemsize(),
             mode="cycle",
         )
-    chunks = ensure_shape_5d(chunks)
-    return chunks
-
-
-def _create_pyramid(
-    data: Union[NDArray, dask.array.Array], n_lvls: int, chunks: Union[str, tuple] = "preserve"
-) -> List[Union[NDArray, dask.array.Array]]:
-    """
-    Create a lazy multiscale image pyramid using data as the full-resolution layer.
-    To evaluate the result, call dask.compute(*pyramid)
-
-    Args:
-        data: the numpy or dask array to create a pyramid from.
-        This will be used as the highest resolution layer.
-        n_lvls: the number of pyramid levels to produce
-    Returns:
-        A list of dask or numpy arrays, ordered from highest resolution to lowest
-    """
-    pyramid = multiscale(
-        data,
-        windowed_mean,  # func
-        (2,) * data.ndim,  # scale factors
-        preserve_dtype=True,
-        chunks=chunks
-    )[:n_lvls]
-    return [arr.data for arr in pyramid]
-
-
-def _get_or_create_pyramid(reader, n_levels, chunks):
-    if isinstance(reader, ImarisReader):
-        try:
-            pyramid = reader.get_dask_pyramid(
-                n_levels,
-                timepoint=0,
-                channel=0,
-                # Use only the dimensions that exist in the base image.
-                chunks=chunks,
-            )
-        except MissingDatasetError as e:
-            LOGGER.error(e)
-            LOGGER.warning(
-                f"{reader.get_filepath()} does not contain all requested scales."
-                f"Computing them instead..."
-            )
-            pyramid = _create_pyramid(
-                reader.as_dask_array(chunks=chunks), n_levels, chunks
-            )
-    else:
-        pyramid = _create_pyramid(
-            reader.as_dask_array(chunks=chunks), n_levels, chunks
-        )
-
-    return pyramid
+    return ensure_shape_5d(chunks)
 
 
 def _get_bytes(data: Union[List[NDArray], NDArray]):
@@ -635,8 +606,7 @@ def _build_ome(
     """
     if channel_names is None:
         channel_names = [
-            f"Channel:{image_name}:{i}"
-            for i in range(data_shape[1])
+            f"Channel:{image_name}:{i}" for i in range(data_shape[1])
         ]
     if channel_colors is None:
         channel_colors = [i for i in range(data_shape[1])]
@@ -670,7 +640,7 @@ def _build_ome(
             "defaultT": 0,  # First timepoint to show the user
             "defaultZ": data_shape[2] // 2,  # First Z section to show the user
             "model": "color",  # "color" or "greyscale"
-        }
+        },
     }
     return omero
 
@@ -714,10 +684,9 @@ def _compute_scales(
         ]
     ]
     if translation is not None:
-        transforms[0].append({
-            "type": "translation",
-            "translation": translation
-        })
+        transforms[0].append(
+            {"type": "translation", "translation": translation}
+        )
     chunk_sizes = []
     lastz = data_shape[2]
     lasty = data_shape[3]
@@ -751,25 +720,29 @@ def _compute_scales(
                 ]
             )
             if translation is not None:
-                transforms[-1].append({
-                    "type": "translation",
-                    "translation": translation
-                })
+                transforms[-1].append(
+                    {"type": "translation", "translation": translation}
+                )
             lastz = int(math.ceil(lastz / scale_factor[0]))
             lasty = int(math.ceil(lasty / scale_factor[1]))
             lastx = int(math.ceil(lastx / scale_factor[2]))
-            opts = dict(chunks=(
-                1,
-                1,
-                min(lastz, chunks[2]),
-                min(lasty, chunks[3]),
-                min(lastx, chunks[4])))
+            opts = dict(
+                chunks=(
+                    1,
+                    1,
+                    min(lastz, chunks[2]),
+                    min(lasty, chunks[3]),
+                    min(lastx, chunks[4]),
+                )
+            )
             chunk_sizes.append(opts)
 
     return transforms, chunk_sizes
 
 
-def _get_axes_5d(time_unit: str = "millisecond", space_unit: str = "micrometer") -> List[Dict]:
+def _get_axes_5d(
+    time_unit: str = "millisecond", space_unit: str = "micrometer"
+) -> List[Dict]:
     """Generate the list of axes.
 
     Parameters
@@ -789,3 +762,201 @@ def _get_axes_5d(time_unit: str = "millisecond", space_unit: str = "micrometer")
         {"name": "x", "type": "space", "unit": f"{space_unit}"},
     ]
     return axes_5d
+
+
+def create_pyramid(
+    arr: ArrayLike,
+    n_lvls: int,
+    scale_factors: tuple,
+    chunks: Union[str, tuple] = "preserve",
+) -> list:
+    """
+    Create a multiscale pyramid of the input data.
+
+    Parameters
+    ----------
+    arr : array-like
+        The input data to be downsampled.
+    n_lvls : int
+        The number of pyramid levels to generate.
+    scale_factors : tuple
+        The scale factors for downsampling along each dimension.
+    chunks : tuple
+        The chunk size to use for the output arrays.
+
+    Returns
+    -------
+    list
+        A list of Dask arrays representing the pyramid levels.
+    """
+    pyramid = multiscale(
+        arr,
+        windowed_mean,  # func
+        scale_factors,
+        preserve_dtype=True,
+        chunks=chunks,
+    )[:n_lvls]
+
+    return [arr.data for arr in pyramid]
+
+
+def store_array(
+    arr: da.Array,
+    group: zarr.Group,
+    path: str,
+    block_shape: tuple,
+    compressor: Codec = None,
+) -> zarr.Array:
+    """
+    Store the full resolution layer of a Dask pyramid into a Zarr group.
+
+    Parameters
+    ----------
+    arr : da.Array
+        The input Dask array.
+    group : zarr.Group
+        The output Zarr group.
+    block_shape : Tuple
+        The shape of blocks to use for partitioning the array.
+    compressor : numcodecs.abc.Codec, optional
+        The compression codec to use for the output Zarr array. Default is Blosc with "zstd" method and compression
+        level 1.
+
+    Returns
+    -------
+    zarr.Array
+        The output Zarr array.
+    """
+    ds = group.create_dataset(
+        path,
+        shape=arr.shape,
+        chunks=arr.chunksize,
+        dtype=arr.dtype,
+        compressor=compressor,
+        dimension_separator="/",
+        overwrite=True,
+    )
+
+    BlockedArrayWriter.store(arr, ds, block_shape)
+
+    return ds
+
+
+def downsample_and_store(
+    arr: da.Array,
+    group: zarr.Group,
+    n_lvls: int,
+    scale_factors: Tuple,
+    block_shape: Tuple,
+    compressor: Codec = None,
+) -> list:
+    """
+    Progressively downsample the input array and store the results as separate arrays in a Zarr group.
+
+    Parameters
+    ----------
+    first_mipmap : da.Array
+        The input Dask array.
+    group : zarr.Group
+        The output Zarr group.
+    n_lvls : int
+        The number of pyramid levels.
+    scale_factors : Tuple
+        The scale factors for downsampling along each dimension.
+    block_shape : Tuple
+        The shape of blocks to use for partitioning the array.
+    compressor : numcodecs.abc.Codec, optional
+        The compression codec to use for the output Zarr array. Default is Blosc with "zstd" method and compression
+        level 1.
+    """
+    pyramid = [arr]
+
+    for arr_index in range(1, n_lvls):
+        first_mipmap = _get_first_mipmap_level(arr, scale_factors)
+
+        ds = group.create_dataset(
+            str(arr_index),
+            shape=first_mipmap.shape,
+            chunks=first_mipmap.chunksize,
+            dtype=first_mipmap.dtype,
+            compressor=compressor,
+            dimension_separator="/",
+            overwrite=True,
+        )
+
+        BlockedArrayWriter.store(first_mipmap, ds, block_shape)
+
+        arr = da.from_array(ds, ds.chunks)
+        pyramid.append(arr)
+
+    return pyramid
+
+
+def _get_first_mipmap_level(arr: da.Array, scale_factors: tuple) -> da.Array:
+    """
+    Generate a mipmap pyramid from the input array and return the first mipmap level.
+
+    Parameters:
+    - arr: dask.array.Array
+        The input array for which the mipmap pyramid is to be generated.
+    - scale_factors: tuple
+        A 5D tuple of scale factors for each dimension used to generate the mipmap pyramid.
+
+    Returns:
+    - dask.array.Array
+        The first mipmap level of the input array.
+    """
+    n_lvls = 2
+    pyramid = create_pyramid(arr, n_lvls, scale_factors, arr.chunksize)
+    return ensure_array_5d(pyramid[1])
+
+
+def write_ome_ngff_metadata(
+    group: zarr.Group,
+    arr: da.Array,
+    image_name: str,
+    n_lvls: int,
+    scale_factors: tuple,
+    voxel_size: tuple,
+    origin: list = None,
+) -> None:
+    """
+    Write OME-NGFF metadata to a Zarr group.
+
+    Parameters
+    ----------
+    group : zarr.Group
+        The output Zarr group.
+    arr : array-like
+        The input array.
+    image_name : str
+        The name of the image.
+    n_lvls : int
+        The number of pyramid levels.
+    scale_factors : tuple
+        The scale factors for downsampling along each dimension.
+    voxel_size : tuple
+        The voxel size along each dimension.
+    """
+    fmt = CurrentFormat()
+    ome_json = _build_ome(
+        arr.shape,
+        image_name,
+        channel_names=None,
+        channel_colors=None,
+        channel_minmax=None,
+    )
+    group.attrs["omero"] = ome_json
+    axes_5d = _get_axes_5d()
+    coordinate_transformations, chunk_opts = _compute_scales(
+        n_lvls, scale_factors, voxel_size, arr.chunksize, arr.shape, origin
+    )
+    fmt.validate_coordinate_transformations(
+        arr.ndim, n_lvls, coordinate_transformations
+    )
+    datasets = [{"path": str(i)} for i in range(n_lvls)]
+    if coordinate_transformations is not None:
+        for dataset, transform in zip(datasets, coordinate_transformations):
+            dataset["coordinateTransformations"] = transform
+
+    write_multiscales_metadata(group, datasets, fmt, axes_5d)

--- a/src/aind_data_transfer/util/chunk_utils.py
+++ b/src/aind_data_transfer/util/chunk_utils.py
@@ -122,7 +122,7 @@ def expand_chunks(
         the optimal chunk shape
     """
     if any(c < 1 for c in chunks):
-        raise ValueError("data_shape must be >= 1 for all dimensions")
+        raise ValueError("chunks must be >= 1 for all dimensions")
     if any(s < 1 for s in data_shape):
         raise ValueError("data_shape must be >= 1 for all dimensions")
     if any(c > s for c, s in zip(chunks, data_shape)):
@@ -141,14 +141,11 @@ def expand_chunks(
         ndims = len(current)
         while _get_size(current, itemsize) < target_size:
             prev = current.copy()
-            current[idx % ndims] *= 2
+            current[idx % ndims] = min(data_shape[idx % ndims], current[idx % ndims] * 2)
             idx += 1
-        current = _closer_to_target(current, prev, target_size, itemsize)
-        expanded = (
-            min(data_shape[0], current[0]),
-            min(data_shape[1], current[1]),
-            min(data_shape[2], current[2]),
-        )
+            if all(c >= s for c, s in zip(current, data_shape)):
+                break
+        expanded = _closer_to_target(current, prev, target_size, itemsize)
     elif mode == "iso":
         initial = np.array(chunks, dtype=np.uint64)
         current = initial
@@ -157,13 +154,15 @@ def expand_chunks(
         while _get_size(current, itemsize) < target_size:
             prev = current
             current = initial * i
+            current = (
+                min(data_shape[0], current[0]),
+                min(data_shape[1], current[1]),
+                min(data_shape[2], current[2]),
+            )
             i += 1
-        current = _closer_to_target(current, prev, target_size, itemsize)
-        expanded = (
-            min(data_shape[0], current[0]),
-            min(data_shape[1], current[1]),
-            min(data_shape[2], current[2]),
-        )
+            if all(c >= s for c, s in zip(current, data_shape)):
+                break
+        expanded = _closer_to_target(current, prev, target_size, itemsize)
     else:
         raise ValueError(f"Invalid mode {mode}")
 

--- a/src/aind_data_transfer/util/io_utils.py
+++ b/src/aind_data_transfer/util/io_utils.py
@@ -423,7 +423,6 @@ class DataReaderFactory:
 
 
 class BlockedArrayWriter:
-    DEFAULT_BLOCK_SHAPE = ()
 
     @staticmethod
     def gen_slices(

--- a/src/aind_data_transfer/util/io_utils.py
+++ b/src/aind_data_transfer/util/io_utils.py
@@ -498,14 +498,14 @@ class BlockedArrayWriter:
             )
 
     @staticmethod
-    def get_block_shape(arr, target_size_mb=102400, mode="cycle"):
+    def get_block_shape(arr, target_size_mb=409600, mode="cycle"):
         """
         Given the shape and chunk size of a pre-chunked array, determine the optimal block shape
         closest to target_size. Expanded block dimensions are an integer multiple of the chunk dimension
         to ensure optimal access patterns.
         Args:
             arr: the input array
-            target_size_mb: target block size in megabytes
+            target_size_mb: target block size in megabytes, default is 409600
             mode: strategy. Must be one of "cycle", or "iso"
         Returns:
             the block shape

--- a/src/aind_data_transfer/util/io_utils.py
+++ b/src/aind_data_transfer/util/io_utils.py
@@ -5,11 +5,12 @@ import re
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Generator
 
 import dask.array as da
 import fsspec
 import h5py
+
 # Importing this alone doesn't work on HPC
 # Must manually override HDF5_PLUGIN_PATH environment variable
 # in each Dask worker
@@ -17,6 +18,8 @@ import hdf5plugin
 import numpy as np
 import ujson
 import zarr
+from aind_data_transfer.util.chunk_utils import expand_chunks
+from numpy.typing import ArrayLike
 from kerchunk.tiff import tiff_to_zarr
 from numpy import dtype
 
@@ -83,20 +86,19 @@ class TiffReader(DataReader):
         # be run from a location accessible by all nodes.
         self._temp_dir = tempfile.TemporaryDirectory(dir=os.getcwd())
         self._refs_file = os.path.join(
-            self._temp_dir.name,
-            f"references-{Path(filepath).name}.json"
+            self._temp_dir.name, f"references-{Path(filepath).name}.json"
         )
         if os.path.isfile(self._refs_file):
-            raise Exception(f"References file already exists: {self._refs_file}")
+            raise Exception(
+                f"References file already exists: {self._refs_file}"
+            )
         Path(self._refs_file).parent.mkdir(parents=True, exist_ok=True)
-        with open(self._refs_file, 'wb') as f:
+        with open(self._refs_file, "wb") as f:
             f.write(ujson.dumps(refs).encode())
         fs = fsspec.filesystem(
-            "reference",
-            fo=self._refs_file,
-            remote_protocol='file'
+            "reference", fo=self._refs_file, remote_protocol="file"
         )
-        self._arr = zarr.open(fs.get_mapper(""), 'r')
+        self._arr = zarr.open(fs.get_mapper(""), "r")
 
     def __enter__(self):
         return self
@@ -116,8 +118,7 @@ class TiffReader(DataReader):
         # For performance it is *critical* the initial dask array construction
         # uses single plane chunks, and to then rechunk with the desired chunks
         a = da.from_array(
-            self._arr,
-            chunks=(1, self._arr.shape[-2], self._arr.shape[-1])
+            self._arr, chunks=(1, self._arr.shape[-2], self._arr.shape[-1])
         )
         if chunks is not None:
             a = a.rechunk(chunks)
@@ -185,7 +186,9 @@ class ImarisReader(DataReader):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def as_dask_array(self, data_path: str = DEFAULT_DATA_PATH, chunks=True) -> da.Array:
+    def as_dask_array(
+        self, data_path: str = DEFAULT_DATA_PATH, chunks=True
+    ) -> da.Array:
         """Return the image stack as a Dask Array
 
         Args:
@@ -202,18 +205,26 @@ class ImarisReader(DataReader):
         # This array is 0-padded to be divisible by the Imaris chunk size in each dimension
         a = da.from_array(self.get_dataset(data_path), chunks=chunks)
         # Crop to the "real" shape at the given resolution
-        return a[:real_shape_at_lvl[0], :real_shape_at_lvl[1], :real_shape_at_lvl[2]]
+        return a[
+            : real_shape_at_lvl[0],
+            : real_shape_at_lvl[1],
+            : real_shape_at_lvl[2],
+        ]
 
     def as_array(self, data_path=DEFAULT_DATA_PATH) -> np.ndarray:
         """
         Get the image stack as a ndarray
-        
+
         Args:
             data_path: the path to the dataset
         """
         lvl = self._get_res_lvl(data_path)
         real_shape_at_lvl = self._get_shape_at_lvl(lvl)
-        return self.get_dataset(data_path)[:real_shape_at_lvl[0], :real_shape_at_lvl[1], :real_shape_at_lvl[2]]
+        return self.get_dataset(data_path)[
+            : real_shape_at_lvl[0],
+            : real_shape_at_lvl[1],
+            : real_shape_at_lvl[2],
+        ]
 
     def get_dataset(self, data_path=DEFAULT_DATA_PATH) -> h5py.Dataset:
         """
@@ -232,7 +243,11 @@ class ImarisReader(DataReader):
         Get the shape of the image
         """
         info = self.get_dataset_info()
-        return int(info.attrs["Z"].tobytes()), int(info.attrs["Y"].tobytes()), int(info.attrs["X"].tobytes())
+        return (
+            int(info.attrs["Z"].tobytes()),
+            int(info.attrs["Y"].tobytes()),
+            int(info.attrs["X"].tobytes()),
+        )
 
     def get_chunks(self, data_path=DEFAULT_DATA_PATH) -> tuple:
         """
@@ -259,11 +274,11 @@ class ImarisReader(DataReader):
         return self.handle
 
     def get_dask_pyramid(
-            self,
-            num_levels: int,
-            timepoint: int = 0,
-            channel: int = 0,
-            chunks: Any = True
+        self,
+        num_levels: int,
+        timepoint: int = 0,
+        channel: int = 0,
+        chunks: Any = True,
     ) -> List[da.Array]:
         """
         Get a multiscale image pyramid as a list of dask arrays.
@@ -356,12 +371,25 @@ class ImarisReader(DataReader):
         lvl_rgx = r"/ResolutionLevel (\d+)/"
         m = re.search(lvl_rgx, data_path)
         if m is None:
-            raise Exception(f"Could not parse resolution level from path {data_path}")
+            raise Exception(
+                f"Could not parse resolution level from path {data_path}"
+            )
         return int(m.group(1))
 
     def _get_shape_at_lvl(self, lvl: int):
         shape = self.get_shape()
         return tuple(int(math.ceil(s / 2**lvl)) for s in shape)
+
+    @property
+    def n_levels(self):
+        lvl = 0
+        while True:
+            ds_path = (
+                f"/DataSet/ResolutionLevel {lvl}/TimePoint 0/Channel 0/Data"
+            )
+            if ds_path not in self.get_handle():
+                return lvl
+            lvl += 1
 
 
 class DataReaderFactory:
@@ -392,3 +420,106 @@ class DataReaderFactory:
         if ext not in self.VALID_EXTENSIONS:
             raise NotImplementedError(f"File type {ext} not supported")
         return self.factory[ext](filepath)
+
+
+class BlockedArrayWriter:
+    DEFAULT_BLOCK_SHAPE = ()
+
+    @staticmethod
+    def gen_slices(
+        arr_shape: Tuple[int, ...], block_shape: Tuple[int, ...]
+    ) -> Generator:
+        """
+        Generate a series of slices that can be used to traverse an array in blocks of a given shape.
+
+        The method generates tuples of slices, each representing a block of the array. The blocks are generated by
+        iterating over the array in steps of the block shape along each dimension.
+
+        Parameters
+        ----------
+        arr_shape : tuple of int
+            The shape of the array to be sliced.
+
+        block_shape : tuple of int
+            The desired shape of the blocks. This should be a tuple of integers representing the size of each
+            dimension of the block. The length of `block_shape` should be equal to the length of
+            `arr_shape`. If the array shape is not divisible by the block shape along a dimension, the last slice
+            along that dimension is truncated.
+
+        Returns
+        -------
+        generator of tuple of slice
+            A generator yielding tuples of slices. Each tuple can be used to index the input array.
+        """
+        if len(arr_shape) != len(block_shape):
+            raise Exception(
+                "array shape and block shape have different lengths"
+            )
+
+        def _slice_along_dim(dim: int) -> Generator:
+            """A helper generator function that slices along one dimension."""
+            # Base case: if the dimension is beyond the last one, return an empty tuple
+            if dim >= len(arr_shape):
+                yield ()
+            else:
+                # Iterate over the current dimension in steps of the block size
+                for i in range(0, arr_shape[dim], block_shape[dim]):
+                    # Calculate the end index for this block
+                    end_i = min(i + block_shape[dim], arr_shape[dim])
+                    # Generate slices for the remaining dimensions
+                    for rest in _slice_along_dim(dim + 1):
+                        yield (slice(i, end_i),) + rest
+
+        # Start slicing along the first dimension
+        return _slice_along_dim(0)
+
+    @staticmethod
+    def store(
+        in_array: da.Array, out_array: ArrayLike, block_shape: tuple
+    ) -> None:
+        """
+        Partitions the last 3 dimensions of a Dask array into non-overlapping blocks and
+        writes them sequentially to a Zarr array. This is meant to reduce the scheduling burden
+        for massive (terabyte-scale) arrays.
+
+        :param in_array: The input Dask array
+        :param block_shape: Tuple of (block_depth, block_height, block_width)
+        :param out_array: The output array
+        """
+        # Iterate through the input array in steps equal to the block shape dimensions
+        for sl in BlockedArrayWriter.gen_slices(in_array.shape, block_shape):
+            block = in_array[sl]
+            da.store(
+                block,
+                out_array,
+                regions=sl,
+                lock=False,
+                compute=True,
+                return_stored=False,
+            )
+
+    @staticmethod
+    def get_block_shape(arr, target_size_mb=102400, mode="cycle"):
+        """
+        Given the shape and chunk size of a pre-chunked array, determine the optimal block shape
+        closest to target_size. Expanded block dimensions are an integer multiple of the chunk dimension
+        to ensure optimal access patterns.
+        Args:
+            arr: the input array
+            target_size_mb: target block size in megabytes
+            mode: strategy. Must be one of "cycle", or "iso"
+        Returns:
+            the block shape
+        """
+        if isinstance(arr, da.Array):
+            chunks = arr.chunksize[-3:]
+        else:
+            chunks = arr.chunks[-3:]
+
+        return expand_chunks(
+            chunks,
+            arr.shape[-3:],
+            target_size_mb * 1024**2,
+            arr.itemsize,
+            mode,
+        )

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -11,7 +11,10 @@ import zarr
 from distributed import Client
 from parameterized import parameterized
 
-from aind_data_transfer.transformations.ome_zarr import write_files, write_folder
+from aind_data_transfer.transformations.ome_zarr import (
+    write_files,
+    write_folder,
+)
 from aind_data_transfer.util.io_utils import ImarisReader
 
 
@@ -25,7 +28,9 @@ def _write_test_h5(folder, n=4, shape=(64, 128, 128)):
     for i in range(n):
         a = np.ones(shape, dtype=np.uint16)
         with h5py.File(os.path.join(folder, f"data_{i}.h5"), "w") as f:
-            f.create_dataset(ImarisReader.DEFAULT_DATA_PATH, data=a, chunks=True)
+            f.create_dataset(
+                ImarisReader.DEFAULT_DATA_PATH, data=a, chunks=True
+            )
             # Write origin metadata
             dataset_info = f.create_group("DataSetInfo/Image")
             dataset_info.attrs["ExtMin0"] = np.array(
@@ -37,15 +42,9 @@ def _write_test_h5(folder, n=4, shape=(64, 128, 128)):
             dataset_info.attrs["ExtMin2"] = np.array(
                 ["3", "0", "0"], dtype="S"
             )
-            dataset_info.attrs["X"] = np.array(
-                list(str(shape[2])), dtype="S"
-            )
-            dataset_info.attrs["Y"] = np.array(
-                list(str(shape[1])), dtype="S"
-            )
-            dataset_info.attrs["Z"] = np.array(
-                list(str(shape[0])), dtype="S"
-            )
+            dataset_info.attrs["X"] = np.array(list(str(shape[2])), dtype="S")
+            dataset_info.attrs["Y"] = np.array(list(str(shape[1])), dtype="S")
+            dataset_info.attrs["Z"] = np.array(list(str(shape[0])), dtype="S")
 
 
 class TestOmeZarr(unittest.TestCase):
@@ -180,7 +179,7 @@ class TestOmeZarr(unittest.TestCase):
         shape = (64, 128, 128)
         out_zarr = os.path.join(self._temp_dir.name, "ome.zarr")
         n_levels = 4
-        scale_factor = 2.0
+        scale_factor = 2
         voxel_size = [1.0, 1.0, 1.0]
         metrics = write_files(
             files, out_zarr, n_levels, scale_factor, voxel_size=voxel_size
@@ -191,7 +190,12 @@ class TestOmeZarr(unittest.TestCase):
         z = zarr.open(out_zarr, "r")
 
         # Test group for each written image
-        expected_keys = {"data_0.zarr", "data_1.zarr", "data_2.zarr", "data_3.zarr"}
+        expected_keys = {
+            "data_0.zarr",
+            "data_1.zarr",
+            "data_2.zarr",
+            "data_3.zarr",
+        }
         actual_keys = set(z.keys())
         self.assertEqual(expected_keys, actual_keys)
 
@@ -215,7 +219,7 @@ class TestOmeZarr(unittest.TestCase):
         shape = (64, 128, 128)
         out_zarr = os.path.join(self._temp_dir.name, "ome.zarr")
         n_levels = 4
-        scale_factor = 2.0
+        scale_factor = 2
         voxel_size = [1.0, 1.0, 1.0]
 
         # create a dummy file to exclude from conversion
@@ -234,7 +238,12 @@ class TestOmeZarr(unittest.TestCase):
         z = zarr.open(out_zarr, "r")
 
         # Test that all images were written except exclusion
-        expected_keys = {"data_0.zarr", "data_1.zarr", "data_2.zarr", "data_3.zarr"}
+        expected_keys = {
+            "data_0.zarr",
+            "data_1.zarr",
+            "data_2.zarr",
+            "data_3.zarr",
+        }
         actual_keys = set(z.keys())
         self.assertEqual(expected_keys, actual_keys)
 


### PR DESCRIPTION
This PR implements a blocked writing strategy for OME-Zarr datasets. Dask arrays are partitioned into non-overlapping blocks of size ~400GiB and processed serially. Parallel processing is done within each block. This basically eliminates the scheduler overhead and OOM errors I was seeing when processing whole tiles / brain volumes at once, and doesn't slow down the writing. For downsampling (diSPIM), the previous level is re-read from either the output s3 bucket (levels 1-n) or disk (level 0), which significantly speeds up pyramid generation since previously the full-resolution layer was re-read for each downsampling level. 

Changes
* `BlockedArrayWriter` class which handles the array partitioning and writing. `ome-zarr-py` is only used for writing the OME-NGFF metadata now.
* Drops support for Python `3.8`, necessary for latest versions of Dask
* Adds support for Python `3.11` - transcode job tested, ephys jobs *not tested* but all unit tests pass
* Updates dependencies `dask==2023.7.1`, `distributed==2023.7.1`, `ome-zarr-py==0.8.0`, `zarr==2.16.0`
* Fixes chunk computation methods
* Misc code cleanup

Tested on CentOS 7