### PR TITLE
Feat: script for converting N5 datasets to OME-Zarr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ imaging = [
     'parameterized',
     'zarr==2.16.0',
     'ome-zarr==0.8.0',
-    'chardet==5.1.0'
+    'chardet==5.1.0',
+    'natsort',
 ]
 full = [
     'aind-data-transfer[ephys]',

--- a/scripts/convert_n5_zarr.py
+++ b/scripts/convert_n5_zarr.py
@@ -1,0 +1,166 @@
+import argparse
+import logging
+import re
+import time
+from pathlib import Path
+from typing import List
+
+import dask.array as da
+import zarr
+from numcodecs import blosc
+from natsort import natsorted
+
+from aind_data_transfer.transformations.ome_zarr import (
+    downsample_and_store,
+    store_array,
+    write_ome_ngff_metadata,
+)
+from aind_data_transfer.util.chunk_utils import (
+    ensure_array_5d,
+    ensure_shape_5d,
+)
+from aind_data_transfer.util.dask_utils import get_client
+from aind_data_transfer.util.io_utils import BlockedArrayWriter
+
+blosc.use_threads = False
+
+logging.basicConfig(format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M")
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert an N5 dataset to OME-Zarr."
+    )
+    parser.add_argument(
+        "--n5",
+        type=str,
+        help="Path to the input N5 container.",
+        required=True
+    )
+    parser.add_argument(
+        "--output-zarr",
+        type=str,
+        help="Path to the output Zarr array.",
+        required=True
+    )
+    parser.add_argument(
+        "--voxel-size", type=float, nargs="+", default=[1.0, 1.0, 1.0]
+    )
+    parser.add_argument("--n-levels", type=int, default=1)
+    parser.add_argument(
+        "--scale-factors", type=int, nargs=3, default=[2, 2, 2]
+    )
+    parser.add_argument("--deployment", type=str, default="slurm")
+
+    return parser.parse_args()
+
+
+def get_n5_scales(n5_group: zarr.Group) -> List[da.Array]:
+    """
+    Returns a list of Dask arrays corresponding to scale datasets in an N5 container,
+    where the dataset name matches the pattern "s" followed by one or more digits.
+
+    Parameters
+    ----------
+    n5_group : Group
+        A Group in an N5/Zarr container.
+
+    Returns
+    -------
+    list
+        A list of Dask arrays corresponding to the scales.
+    """
+    scales = []
+    pattern = re.compile("^s[0-9]+$")
+    for item in natsorted(n5_group.keys()):
+        if pattern.match(item):
+            _LOGGER.info(f"Found scale {item}")
+            ds = n5_group[item]
+            scales.append(da.from_array(ds, chunks=ds.chunks))
+    return scales
+
+
+def main():
+    args = parse_arguments()
+
+    n_levels = args.n_levels
+    if n_levels <= 0:
+        raise ValueError("Number of levels must be > 0")
+
+    scale_factors = args.scale_factors
+    if len(scale_factors) != 3:
+        raise ValueError("Scale factors must be 3D")
+    if any(s <= 0 for s in scale_factors):
+        raise ValueError("Scale factors must be > 0")
+
+    voxel_size = args.voxel_size
+    if len(voxel_size) != 3:
+        raise ValueError("Voxel size must be 3D")
+    if any(s <= 0 for s in voxel_size):
+        raise ValueError("Voxel size must be > 0")
+
+    client, _ = get_client(deployment=args.deployment)
+
+    # Load the input Dask array(s) from N5 container
+    z = zarr.open(zarr.N5FSStore(args.n5), "r")
+    scales = get_n5_scales(z)
+    if not scales:
+        _LOGGER.error("No scales found")
+        return
+
+    scales = [ensure_array_5d(scale) for scale in scales]
+    _LOGGER.info(f"input array: {scales[0]}")
+    _LOGGER.info(f"input array size: {scales[0].nbytes / 2 ** 20} MiB")
+
+    # TODO: let user set chunk shape?
+
+    block_shape = ensure_shape_5d(
+        BlockedArrayWriter.get_block_shape(scales[0], target_size_mb=409600)
+    )
+    _LOGGER.info(f"block shape: {block_shape}")
+
+    scale_factors = ensure_shape_5d(scale_factors)
+    _LOGGER.info(f"scale factors: {scale_factors}")
+
+    _LOGGER.info(f"Writing OME-Zarr to {args.output_zarr}")
+
+    root_group: zarr.Group = zarr.open(args.output_zarr, mode="w")
+
+    write_ome_ngff_metadata(
+        root_group,
+        scales[0],
+        Path(args.output_zarr).stem,
+        n_levels,
+        scale_factors[-3:],  # must be 3D
+        tuple(reversed(args.voxel_size)),  # must be 3D ZYX
+    )
+
+    codec = blosc.Blosc(cname="zstd", clevel=1, shuffle=blosc.SHUFFLE)
+
+    t0 = time.time()
+    if len(scales) < n_levels:
+        # downsample from scratch
+        _LOGGER.info(
+            "Num existing scales is less than num levels, downsampling from scratch."
+        )
+        store_array(scales[0], root_group, "0", block_shape, codec)
+        downsample_and_store(
+            scales[0],
+            root_group,
+            n_levels,
+            scale_factors,
+            block_shape,
+            codec,
+        )
+    else:
+        for i, s in enumerate(scales):
+            store_array(s, root_group, str(i), block_shape, codec)
+            if i == n_levels - 1:
+                break
+    _LOGGER.info(f"Done. Took {time.time() - t0} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -942,6 +942,7 @@ def write_ome_ngff_metadata(
     scale_factors: tuple,
     voxel_size: tuple,
     origin: list = None,
+    metadata: dict = None,
 ) -> None:
     """
     Write OME-NGFF metadata to a Zarr group.
@@ -961,6 +962,8 @@ def write_ome_ngff_metadata(
     voxel_size : tuple
         The voxel size along each dimension.
     """
+    if metadata is None:
+        metadata = {}
     fmt = CurrentFormat()
     ome_json = _build_ome(
         arr.shape,
@@ -982,4 +985,4 @@ def write_ome_ngff_metadata(
         for dataset, transform in zip(datasets, coordinate_transformations):
             dataset["coordinateTransformations"] = transform
 
-    write_multiscales_metadata(group, datasets, fmt, axes_5d)
+    write_multiscales_metadata(group, datasets, fmt, axes_5d, **metadata)

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -12,7 +12,7 @@ from ome_zarr.format import CurrentFormat
 from ome_zarr.io import parse_url
 from ome_zarr.writer import write_multiscales_metadata
 from xarray_multiscale import multiscale
-from xarray_multiscale.reducers import windowed_mean
+from xarray_multiscale.reducers import windowed_mean, WindowedReducer
 
 from aind_data_transfer.util.chunk_utils import *
 from aind_data_transfer.util.file_utils import collect_filepaths
@@ -785,10 +785,11 @@ def _get_axes_5d(
 
 
 def create_pyramid(
-    arr: ArrayLike,
+    arr: Union[np.ndarray, da.Array],
     n_lvls: int,
     scale_factors: tuple,
     chunks: Union[str, tuple] = "preserve",
+    reducer: WindowedReducer = windowed_mean,
 ) -> list:
     """
     Create a multiscale pyramid of the input data.
@@ -810,9 +811,9 @@ def create_pyramid(
         A list of Dask arrays representing the pyramid levels.
     """
     pyramid = multiscale(
-        arr,
-        windowed_mean,  # func
-        scale_factors,
+        array=arr,
+        reduction=reducer,  # func
+        scale_factors=scale_factors,
         preserve_dtype=True,
         chunks=chunks,
     )[:n_lvls]
@@ -870,6 +871,7 @@ def downsample_and_store(
     scale_factors: Tuple,
     block_shape: Tuple,
     compressor: Codec = None,
+    reducer: WindowedReducer = windowed_mean,
 ) -> list:
     """
     Progressively downsample the input array and store the results as separate arrays in a Zarr group.
@@ -893,7 +895,7 @@ def downsample_and_store(
     pyramid = [arr]
 
     for arr_index in range(1, n_lvls):
-        first_mipmap = _get_first_mipmap_level(arr, scale_factors)
+        first_mipmap = _get_first_mipmap_level(arr, scale_factors, reducer)
 
         ds = group.create_dataset(
             str(arr_index),
@@ -913,7 +915,7 @@ def downsample_and_store(
     return pyramid
 
 
-def _get_first_mipmap_level(arr: da.Array, scale_factors: tuple) -> da.Array:
+def _get_first_mipmap_level(arr: da.Array, scale_factors: tuple, reducer: WindowedReducer = windowed_mean) -> da.Array:
     """
     Generate a mipmap pyramid from the input array and return the first mipmap level.
 
@@ -928,7 +930,7 @@ def _get_first_mipmap_level(arr: da.Array, scale_factors: tuple) -> da.Array:
         The first mipmap level of the input array.
     """
     n_lvls = 2
-    pyramid = create_pyramid(arr, n_lvls, scale_factors, arr.chunksize)
+    pyramid = create_pyramid(arr, n_lvls, scale_factors, arr.chunksize, reducer)
     return ensure_array_5d(pyramid[1])
 
 


### PR DESCRIPTION
The script takes a BigDataViewer-style multiscale N5 (on disk or cloud) and converts it to OME-Zarr. If there are fewer scales in the N5 than desired, the pyramid is generated from scratch. 

**Benchmarks**
In this case all scales exist in the N5, so no downsampling was done.
Source N5 (multiscale, GZip compressed): `s3://aind-open-data/exaSPIM_650010_2023-04-04_17-42-51_fusion_2023-04-23_11-35-00/fused.n5`
Dest Zarr (multiscale, Blosc Zstd compressed): another S3 bucket
Machine: Allen HPC
N Cores: `64`
Raw data size (all pyramid levels): `89187 GiB`
Conversion time: `65563s`
Speed: `1.36GiB/s`
N5 chunk size: `(256, 256, 256)`
Zarr chunk size: `(256, 256, 256)`
