### PR TITLE
ci: adds instructions on how to build singularity image

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-python -m pip install "git+https://github.com/AllenNeuralDynamics/aind-ng-link@feat-zarr-checker#egg=aind-ng-link"
-python -m pip install "git+https://github.com/fsspec/kerchunk"
-python -m pip install hdf5plugin --no-binary hdf5plugin
+python -m pip install "git+https://github.com/AllenNeuralDynamics/aind-ng-link@feat-zarr-checker#egg=aind-ng-link" --no-cache-dir
+python -m pip install "git+https://github.com/fsspec/kerchunk" --no-cache-dir
+python -m pip install hdf5plugin --no-binary hdf5plugin --no-cache-dir

--- a/scripts/singularity/Dockerfile
+++ b/scripts/singularity/Dockerfile
@@ -46,4 +46,4 @@ make -C ./builddir install
 RUN mkdir build
 
 # Copy def file and post_install script
-COPY ["scripts/singularity/aind_data_transfer.def", "post_install.sh", "./"]
+COPY ["scripts/singularity/aind_data_transfer.def", "scripts/singularity/build_sif.sh","post_install.sh", "./"]

--- a/scripts/singularity/Dockerfile
+++ b/scripts/singularity/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:22.04
+
+# Install packages
+
+RUN apt-get update && apt-get install -y \
+build-essential \
+libssl-dev \
+uuid-dev \
+libgpgme11-dev \
+squashfs-tools \
+libseccomp-dev \
+wget \
+pkg-config \
+procps
+
+# Download Go source, install them and modify the PATH
+
+ARG GO_VERSION=1.14.12 
+ARG GO_OS=linux 
+ARG GO_ARCH=amd64
+
+RUN wget https://dl.google.com/go/go$GO_VERSION.$GO_OS-$GO_ARCH.tar.gz && \
+tar -C /usr/local -xzvf go$GO_VERSION.$GO_OS-$GO_ARCH.tar.gz && \
+rm go$GO_VERSION.$GO_OS-$GO_ARCH.tar.gz && \
+echo 'export PATH=$PATH:/usr/local/go/bin' | tee -a /etc/profile
+
+# Download Singularity
+
+
+ARG SINGULARITY_VERSION=3.7.0
+
+RUN wget https://github.com/hpcng/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-${SINGULARITY_VERSION}.tar.gz && \
+tar -xzf singularity-${SINGULARITY_VERSION}.tar.gz &&\
+rm singularity-${SINGULARITY_VERSION}.tar.gz
+
+# Compile Singularity sources and install it
+
+RUN export PATH=$PATH:/usr/local/go/bin && \
+cd singularity && \
+./mconfig --without-suid && \
+make -C ./builddir && \
+make -C ./builddir install
+
+# Create a directory to store the sif file
+
+RUN mkdir build
+
+# Copy def file and post_install script
+COPY ["scripts/singularity/aind_data_transfer.def", "post_install.sh", "./"]

--- a/scripts/singularity/README.md
+++ b/scripts/singularity/README.md
@@ -2,11 +2,12 @@
 
 ### Build Singularity-Builder
 
-TODO: We should build these automatically and register them somewhere.
+TODO: We should build the singularity-builder docker container in a different repo
 
-- From the project's root directory:
-- Make a local build directory. Run `mkdir build`
-- Build a docker image. Run `docker build -t singularity-builder:latest -f scripts/singularity/Dockerfile .`
-- Build the singularity image. Run: `docker run --privileged -v ${PWD}/build:/build singularity-builder:latest singularity build build/aind_data_transfer.sif aind_data_transfer.def`
-- There should be a sif file in the build folder. The permissions may need to be updated.
-- The sif file can now be copied to a shared directory that a slurm cluster can access.
+- From the project's root directory and from the main branch:
+- Run: `./scripts/singularity/run_build.sh`
+- After the build completes, there should be a sif file that can now be copied to a shared directory that a slurm cluster can access.
+
+### To build an older version other than the latest
+- If the docker image is already built, you can create a sif file for a specific version by running: `docker run --privileged -e AIND_DATA_TRANSFER_VERSION=${AIND_DATA_TRANSFER_VERSION} -v ${PWD}/build:/build singularity-builder:latest ./build_sif.sh`
+- Alternatively, you can checkout a specific tag and run `./scripts/singularity/run_build.sh`

--- a/scripts/singularity/README.md
+++ b/scripts/singularity/README.md
@@ -1,0 +1,12 @@
+# How to build a singularity image that can be used to run aind-data-transfer on the HPC
+
+### Build Singularity-Builder
+
+TODO: We should build these automatically and register them somewhere.
+
+- From the project's root directory:
+- Make a local build directory. Run `mkdir build`
+- Build a docker image. Run `docker build -t singularity-builder:latest -f scripts/singularity/Dockerfile .`
+- Build the singularity image. Run: `docker run --privileged -v ${PWD}/build:/build singularity-builder:latest singularity build build/aind_data_transfer.sif aind_data_transfer.def`
+- There should be a sif file in the build folder. The permissions may need to be updated.
+- The sif file can now be copied to a shared directory that a slurm cluster can access.

--- a/scripts/singularity/aind_data_transfer.def
+++ b/scripts/singularity/aind_data_transfer.def
@@ -1,0 +1,9 @@
+Bootstrap: docker
+From: python:3.9
+
+%files
+    post_install.sh
+
+%post
+    pip install aind-data-transfer[full] --no-cache-dir
+    ./post_install.sh

--- a/scripts/singularity/build_sif.sh
+++ b/scripts/singularity/build_sif.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+SIF_VERSION="${AIND_DATA_TRANSFER_VERSION//./_}"
+echo "AIND_DATA_TRANSFER_VERSION=${AIND_DATA_TRANSFER_VERSION}"
+echo "SIF_VERSION=${SIF_VERSION}"
+
+if [[ -z "${SIF_VERSION}" ]]; then
+  echo "Using latest version"
+  singularity build build/aind_data_transfer_latest.sif aind_data_transfer.def
+  chmod 775 build/aind_data_transfer_latest.sif
+else
+  echo "Using ${SIF_VERSION}"
+  sed -i 's/aind-data-transfer\[full\]/aind-data-transfer\[full\]=='${AIND_DATA_TRANSFER_VERSION}'/g' aind_data_transfer.def
+  cat aind_data_transfer.def | grep aind-data-transfer
+  singularity build build/aind_data_transfer_${SIF_VERSION}.sif aind_data_transfer.def
+  chmod 775 build/aind_data_transfer_${SIF_VERSION}.sif
+fi

--- a/scripts/singularity/run_build.sh
+++ b/scripts/singularity/run_build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Building directory and getting package version"
+mkdir -p build
+AIND_DATA_TRANSFER_VERSION=$(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' src/aind_data_transfer/__init__.py)
+echo ${AIND_DATA_TRANSFER_VERSION}
+
+echo "Building docker container"
+docker build -t singularity-builder:latest --build-arg AIND_DATA_TRANSFER_VERSION=latest -f scripts/singularity/Dockerfile .
+
+echo "Building sif container"
+docker run --privileged -e AIND_DATA_TRANSFER_VERSION=${AIND_DATA_TRANSFER_VERSION} -v ${PWD}/build:/build singularity-builder:latest ./build_sif.sh


### PR DESCRIPTION
Closes #258 

- Adds no-cache-dir to post_install script to reduce size of singularity images
- Adds Dockerfile to build an environment with Singularity installed
- Adds def file to pip install aind-data-transfer[full] and run post_install script
- Add README explaining how to build a singularity image that can be run on the HPC as an alternative to conda envs.