### PR TITLE
fix SPOPHYS experiment type readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Required
 
 ```
 s3_bucket: S3 Bucket name
-experiment_type: One of [confocal, diSPIM, ecephys, exaSPIM, FIP, fMOST, HSFP, mesoSPIM, MPOPHYS, MRI, Other, SmartSPIM, SPOPHYS]
+experiment_type: One of [confocal, diSPIM, ecephys, exaSPIM, FIP, fMOST, HSFP, mesoSPIM, MPOPHYS, MRI, Other, SmartSPIM, single-pane-ophys] (pulled from the modality.abbreviation field)
 modality: One of [CONFOCAL, DISPIM, ECEPHYS, EPHYS, EXASPIM, FIP, FMOST, HSFP, ICEPHYS, MESOSPIM, MPOPHYS, MRI, SMARTSPIM, SPIM, SPOPHYS]
 subject_id: ID of the subject
 acq_date: Format can be either yyyy-MM-dd or MM/dd/yyyy

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Required
 
 ```
 s3_bucket: S3 Bucket name
-experiment_type: One of [confocal, diSPIM, ecephys, exaSPIM, FIP, fMOST, HSFP, mesoSPIM, MPOPHYS, MRI, Other, SmartSPIM, single-pane-ophys] (pulled from the modality.abbreviation field)
+experiment_type: One of [confocal, diSPIM, ecephys, exaSPIM, FIP, fMOST, HSFP, mesoSPIM, MPOPHYS, MRI, Other, SmartSPIM, single-pane-ophys] (pulled from the Modality.abbreviation field)
 modality: One of [CONFOCAL, DISPIM, ECEPHYS, EPHYS, EXASPIM, FIP, FMOST, HSFP, ICEPHYS, MESOSPIM, MPOPHYS, MRI, SMARTSPIM, SPIM, SPOPHYS]
 subject_id: ID of the subject
 acq_date: Format can be either yyyy-MM-dd or MM/dd/yyyy

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Required
 
 ```
 s3_bucket: S3 Bucket name
-experiment_type: One of [confocal, diSPIM, ecephys, exaSPIM, FIP, fMOST, HSFP, mesoSPIM, MPOPHYS, MRI, Other, SmartSPIM, single-pane-ophys] (pulled from the Modality.abbreviation field)
+experiment_type: One of [confocal, diSPIM, ecephys, exaSPIM, FIP, fMOST, HSFP, mesoSPIM, MPOPHYS, MRI, Other, SmartSPIM, single-plane-ophys] (pulled from the Modality.abbreviation field)
 modality: One of [CONFOCAL, DISPIM, ECEPHYS, EPHYS, EXASPIM, FIP, FMOST, HSFP, ICEPHYS, MESOSPIM, MPOPHYS, MRI, SMARTSPIM, SPIM, SPOPHYS]
 subject_id: ID of the subject
 acq_date: Format can be either yyyy-MM-dd or MM/dd/yyyy


### PR DESCRIPTION
closes #269 

updated readme to reflect that:
- SPOPHYS experiment_type field should be `single-pane-ophys` 
- imply that the experiment_type field should be filled with the value of Modality.abbreviation