### PR TITLE
Fix background subtraction

### DIFF
--- a/src/aind_data_transfer/transformations/flatfield_correction.py
+++ b/src/aind_data_transfer/transformations/flatfield_correction.py
@@ -3,7 +3,10 @@ import os
 import re
 from enum import Enum
 
+import dask
 import dask.array as da
+import numpy as np
+import tifffile
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
@@ -26,12 +29,16 @@ class BkgSubtraction:
         Returns:
             Resulting image volume after background subtraction.
         """
-        bkg_da = da.pad(
-            bkg_da,
-            [(0, im.shape[1] - bkg_da.shape[0]), (0, im.shape[2] - bkg_da.shape[1])],
-            mode="edge"
-        )
-        return da.clip((im + 100) - bkg_da, 100, 2 ** 16 - 1) - 100
+        if im.shape[1] != bkg_da.shape[0] or im.shape[2] != bkg_da.shape[1]:
+            _LOGGER.warning(
+                f"Background image shape {bkg_da.shape} does not match image volume shape {im.shape}"
+            )
+            bkg_da = da.pad(
+                bkg_da,
+                [(0, im.shape[1] - bkg_da.shape[0]), (0, im.shape[2] - bkg_da.shape[1])],
+                mode="edge"
+            )
+        return da.clip(im.astype(np.int32) - bkg_da, 0, 2 ** 16 - 1).astype(np.uint16)
 
     @staticmethod
     def get_bkg_path(tile_path: str, bkg_im_dir: str) -> str:
@@ -49,6 +56,24 @@ class BkgSubtraction:
         if m is None:
             raise ValueError(f"tile name does not follow convention: {tile_path}")
         return os.path.join(bkg_im_dir, "bkg_" + m.group(0) + ".tiff")
+
+    @staticmethod
+    def darray_from_bkg_path(bkg_path: str, shape: tuple, chunks: tuple) -> da.Array:
+        """
+        Get a dask array from the background image path.
+
+        Parameters:
+            bkg_path: path to the background image.
+            shape: shape of the background image.
+            chunks: chunking of the background image.
+
+        Returns:
+            dask array of the background image.
+        """
+        bkg = dask.delayed(tifffile.imread)(bkg_path)
+        bkg = da.from_delayed(bkg, shape=shape, dtype=np.uint16)
+        bkg = bkg.rechunk(chunks)
+        return bkg
 
 
 

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -215,6 +215,8 @@ def _store_file(
                 reader.get_shape()[-2:],
                 chunks[-2:],
             )
+            # keep background image in distributed memory
+            bkg = bkg.persist()
             bkg_img_pyramid = create_pyramid(bkg, n_levels, scale_factors[1:])
             for i in range(len(bkg_img_pyramid)):
                 pyramid[i] = BkgSubtraction.subtract(
@@ -260,6 +262,8 @@ def _store_file(
                 reader.get_shape()[-2:],
                 chunks[-2:],
             )
+            # keep background image in distributed memory
+            bkg = bkg.persist()
             arr = BkgSubtraction.subtract(arr, bkg)
 
         arr = ensure_array_5d(arr)

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -4,10 +4,9 @@ import time
 from pathlib import Path
 from typing import List, Optional, Dict, cast
 
-import tifffile
 import zarr
 from numcodecs.abc import Codec
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import NDArray
 from ome_zarr.format import CurrentFormat
 from ome_zarr.io import parse_url
 from ome_zarr.writer import write_multiscales_metadata
@@ -209,19 +208,18 @@ def _store_file(
         )
 
         if bkg_img_dir is not None:
-            bkg_img_pyramid = create_pyramid(
-                tifffile.imread(
-                    BkgSubtraction.get_bkg_path(
-                        reader.get_filepath(), bkg_img_dir
-                    )
+            bkg = BkgSubtraction.darray_from_bkg_path(
+                BkgSubtraction.get_bkg_path(
+                    reader.get_filepath(), bkg_img_dir
                 ),
-                n_levels,
-                scale_factors[1:],
+                reader.get_shape()[-2:],
+                chunks[-2:],
             )
+            bkg_img_pyramid = create_pyramid(bkg, n_levels, scale_factors[1:])
             for i in range(len(bkg_img_pyramid)):
                 pyramid[i] = BkgSubtraction.subtract(
                     pyramid[i],
-                    da.from_array(bkg_img_pyramid[i], chunks=(128, 128)),
+                    bkg_img_pyramid[i],
                 )
 
         # The background subtraction can change the chunks,
@@ -255,16 +253,14 @@ def _store_file(
         arr = reader.as_dask_array(chunks=reader_chunks)
 
         if bkg_img_dir is not None:
-            bkg_img = (
-                tifffile.imread(
-                    BkgSubtraction.get_bkg_path(
-                        reader.get_filepath(), bkg_img_dir
-                    )
+            bkg = BkgSubtraction.darray_from_bkg_path(
+                BkgSubtraction.get_bkg_path(
+                    reader.get_filepath(), bkg_img_dir
                 ),
+                reader.get_shape()[-2:],
+                chunks[-2:],
             )
-            arr = BkgSubtraction.subtract(
-                arr, da.from_array(bkg_img, chunks=(128, 128))
-            )
+            arr = BkgSubtraction.subtract(arr, bkg)
 
         arr = ensure_array_5d(arr)
         # The background subtraction can change the chunks,

--- a/tests/test_flatfield_correction.py
+++ b/tests/test_flatfield_correction.py
@@ -10,12 +10,30 @@ from aind_data_transfer.transformations.flatfield_correction import BkgSubtracti
 class TestBkgSubtraction(unittest.TestCase):
 
     def test_subtract(self):
-        im = da.from_array(np.full((64, 64, 64), fill_value=100, dtype=int), chunks=(16, 16, 16))
-        bkg_im = da.from_array(np.full((32, 32), fill_value=50, dtype=int), chunks=(16, 16))
+        im = da.from_array(np.full((64, 64, 64), fill_value=100, dtype=np.uint16), chunks=(16, 16, 16))
+        bkg_im = da.from_array(np.full((32, 32), fill_value=50, dtype=np.uint16), chunks=(16, 16))
         result = BkgSubtraction.subtract(im, bkg_im)
         self.assertIsInstance(result, da.Array)
         self.assertEqual(result.shape, im.shape)
+        self.assertEqual(result.dtype, np.uint16)
         self.assertEqual(result.sum().compute(), np.product(im.shape) * 50)
+
+        # test when bkg_im is larger than im
+        bkg_im = da.from_array(np.full((128, 128), fill_value=50, dtype=np.uint16), chunks=(16, 16))
+        result = BkgSubtraction.subtract(im, bkg_im)
+        self.assertIsInstance(result, da.Array)
+        self.assertEqual(result.shape, im.shape)
+        self.assertEqual(result.dtype, np.uint16)
+        self.assertEqual(result.sum().compute(), np.product(im.shape) * 50)
+
+        # test clipping behavior
+        im = da.from_array(np.full((64, 64, 64), fill_value=100, dtype=np.uint16), chunks=(16, 16, 16))
+        bkg_im = da.from_array(np.full((64, 64), fill_value=200, dtype=np.uint16), chunks=(16, 16))
+        result = BkgSubtraction.subtract(im, bkg_im)
+        self.assertIsInstance(result, da.Array)
+        self.assertEqual(result.shape, im.shape)
+        self.assertEqual(result.dtype, np.uint16)
+        self.assertEqual(result.sum().compute(), 0)
 
     def test_get_bkg_path(self):
         bkg_im_dir = "path/to/background_images/"


### PR DESCRIPTION
* Fix integer overflow for pixels near uint16 max value
* cast input array to int32 to avoid potential underflow
* load background dask array as part of computation instead of on client machine
* fix dimension adjustments when array sizes are not equal