### PR TITLE
Feat: improve s3_upload.py performance

### DIFF
--- a/scripts/gcs_upload.py
+++ b/scripts/gcs_upload.py
@@ -127,8 +127,12 @@ def run_python_local_job(
                           Increasing this can speed up transfers.
         exclude_dirs (list): list of directory names to exclude, e.g., ["dir1", "dir2"]
     """
-    files = collect_filepaths(
-        input_dir, recursive=True, exclude_dirs=exclude_dirs
+    files = list(
+        collect_filepaths(
+            input_dir,
+            recursive=True,
+            exclude_dirs=exclude_dirs
+        )
     )
     chunked_files = _chunk_files(files, n_workers, tasks_per_worker=1)
     args = zip(

--- a/scripts/make_mips.py
+++ b/scripts/make_mips.py
@@ -82,10 +82,12 @@ def main():
 
     _LOGGER.setLevel(args.log_level)
 
-    image_paths = collect_filepaths(
-        args.input,
-        recursive=True,
-        include_exts=DataReaderFactory().VALID_EXTENSIONS,
+    image_paths = list(
+        collect_filepaths(
+            args.input,
+            recursive=True,
+            include_exts=DataReaderFactory().VALID_EXTENSIONS,
+        )
     )
 
     exclude_paths = set()

--- a/scripts/s3_upload.py
+++ b/scripts/s3_upload.py
@@ -7,18 +7,15 @@ import time
 from datetime import datetime
 from pathlib import PurePath
 
-import numpy as np
 from aind_codeocean_api.codeocean import CodeOceanClient
 from aind_codeocean_api.credentials import CodeOceanCredentials
 from s3transfer.constants import GB, MB
 
 from aind_data_transfer.s3 import S3Uploader
 from aind_data_transfer.util import file_utils
-from aind_data_transfer.util.dask_utils import (
-    get_client,
-    log_dashboard_address,
-)
-from aind_data_transfer.util.file_utils import collect_filepaths
+from aind_data_transfer.util.dask_utils import get_client
+from aind_data_transfer.util.file_utils import collect_filepaths, batch_files_by_size
+
 
 LOG_FMT = "%(asctime)s %(message)s"
 LOG_DATE_FMT = "%Y-%m-%d %H:%M"
@@ -26,18 +23,6 @@ LOG_DATE_FMT = "%Y-%m-%d %H:%M"
 logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATE_FMT)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-def chunk_files(input_dir, ntasks, recursive=True, exclude_dirs=None):
-    filepaths = collect_filepaths(input_dir, recursive, exclude_dirs)
-
-    filepaths_len = len(filepaths)
-
-    if not filepaths_len:
-        return None
-
-    logger.info(f"Collected {filepaths_len} files")
-    return np.array_split(filepaths, ntasks)
 
 
 def upload_files_job(
@@ -66,34 +51,20 @@ def run_cluster_job(
     target_throughput,
     part_size,
     timeout,
-    chunks_per_worker,
-    recursive,
+    batch_size=GB,
+    recursive=True,
     exclude_dirs=None,
 ):
     client, ntasks = get_client(deployment="slurm")
     logger.info(f"Client has {ntasks} registered workers")
 
-    chunked_files = chunk_files(
-        input_dir, ntasks * chunks_per_worker, recursive, exclude_dirs
-    )
-
-    if chunked_files is None:
-        logger.error(f"No files found!")
-        client.close()
-        return -1
-
-    logger.info(
-        f"Split files into {len(chunked_files)} chunks with "
-        f"{len(chunked_files[0])} files each"
-    )
-
     futures = []
-    for chunk in chunked_files:
+    for batch in batch_files_by_size(collect_filepaths(input_dir, recursive, exclude_dirs), batch_size):
         futures.append(
             client.submit(
                 upload_files_job,
                 input_dir=input_dir,
-                files=chunk,
+                files=batch,
                 bucket=bucket,
                 s3_path=s3_path,
                 n_threads=1,
@@ -102,6 +73,11 @@ def run_cluster_job(
                 timeout=timeout,
             )
         )
+    if not futures:
+        logger.error(f"No files found!")
+        client.close()
+        return -1
+
     failed_uploads = list(itertools.chain(*client.gather(futures)))
     n_failed_uploads = len(failed_uploads)
     logger.info(f"{n_failed_uploads} failed uploads:\n{failed_uploads}")
@@ -272,7 +248,7 @@ def main():
     parser.add_argument(
         "--target_throughput",
         type=float,
-        default=100 * GB / 8,
+        default=1000 * GB / 8,
         help="target throughput (bytes)",
     )
     parser.add_argument(
@@ -294,11 +270,10 @@ def main():
         help="run in cluster mode",
     )
     parser.add_argument(
-        "--batch_num",
+        "--batch_size",
         type=int,
-        default=3,
-        help="number of tasks per job. "
-        "Increase this if you run into worker memory issues",
+        default=256 * MB,
+        help="Target total bytes for each batch of files."
     )
     parser.add_argument(
         "--nthreads",
@@ -342,10 +317,7 @@ def main():
 
     input_path = args.input
     bucket = args.bucket
-    n_failed_uploads = -1
-    trigger_code_ocean = args.trigger_code_ocean
     type_spim = args.type_spim.casefold()
-
     s3_path = args.s3_path
     if s3_path is None:
         s3_path = PurePath(args.input).name
@@ -365,7 +337,7 @@ def main():
             target_throughput=args.target_throughput,
             part_size=args.part_size,
             timeout=args.timeout,
-            chunks_per_worker=args.batch_num,
+            batch_size=args.batch_size,
             recursive=args.recursive,
             exclude_dirs=args.exclude_dirs,
         )

--- a/scripts/s3_upload.py
+++ b/scripts/s3_upload.py
@@ -59,7 +59,7 @@ def run_cluster_job(
     logger.info(f"Client has {ntasks} registered workers")
 
     futures = []
-    for batch in batch_files_by_size(collect_filepaths(input_dir, recursive, exclude_dirs), batch_size):
+    for batch in batch_files_by_size(input_dir, batch_size, recursive, exclude_dirs=exclude_dirs):
         futures.append(
             client.submit(
                 upload_files_job,

--- a/src/aind_data_transfer/gcs.py
+++ b/src/aind_data_transfer/gcs.py
@@ -121,7 +121,7 @@ class GCSUploader:
             A list of filepaths for failed uploads
         """
         return self.upload_files(
-            collect_filepaths(folder, recursive),
+            list(collect_filepaths(folder, recursive)),
             gcs_folder,
             root=folder,
             chunk_size=chunk_size,

--- a/src/aind_data_transfer/s3.py
+++ b/src/aind_data_transfer/s3.py
@@ -120,7 +120,7 @@ class S3Uploader:
             A list of filepaths for failed uploads
         """
         return self.upload_files(
-            collect_filepaths(folder, recursive, exclude_dirs=exclude_dirs),
+            list(collect_filepaths(folder, recursive, exclude_dirs=exclude_dirs)),
             s3_bucket,
             s3_folder,
             root=folder,
@@ -144,14 +144,11 @@ def _await_file_upload_futures(
 ) -> List[str]:
     n_files = len(filepaths)
     failed_uploads = []
-    bytes_uploaded = 0
     for i, (fpath, fut) in enumerate(zip(filepaths, futures)):
         try:
             fut.result(timeout)
-            logger.info(f"Uploaded file {i + 1}/{n_files} {fpath}")
-            bytes_uploaded += os.stat(fpath).st_size
+            logger.debug(f"Uploaded file {i + 1}/{n_files} {fpath}")
         except Exception as e:
             logger.error(f"Upload failed for {fpath} \n{e}")
             failed_uploads.append(fpath)
-    logger.info(f"{bytes_uploaded / (1024 ** 2)} MiB uploaded")
     return failed_uploads

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -479,10 +479,12 @@ def write_folder(
     if exclude is None:
         exclude = []
 
-    image_paths = collect_filepaths(
-        input,
-        recursive=recursive,
-        include_exts=DataReaderFactory().VALID_EXTENSIONS,
+    image_paths = list(
+        collect_filepaths(
+            input,
+            recursive=recursive,
+            include_exts=DataReaderFactory().VALID_EXTENSIONS,
+        )
     )
 
     exclude_paths = set()

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -96,7 +96,7 @@ class TestFileUtils(unittest.TestCase):
 
     def test_batch_files_by_size_complex(self):
         # Test target size of 250
-        batches = list(batch_files_by_size(self.test_dir, target_size=250))
+        batches = sorted(list(batch_files_by_size(self.test_dir, target_size=250)))
         expected_batches = [
             ["dir1/file1.txt", "dir1/file2.tiff"],
             ["dir1/sub_dir1/file3.h5", "dir1/sub_dir1/file4.ims", "dir1/sub_dir1/sub_sub_dir1/file5.txt"],
@@ -107,7 +107,7 @@ class TestFileUtils(unittest.TestCase):
         self.assertEqual(batches, expected_batches)
 
         # Test target size of 100
-        batches = list(batch_files_by_size(self.test_dir, target_size=100))
+        batches = sorted(list(batch_files_by_size(self.test_dir, target_size=100)))
         expected_batches = [
             ["dir1/file1.txt"],
             ["dir1/file2.tiff"],
@@ -123,7 +123,7 @@ class TestFileUtils(unittest.TestCase):
         self.assertEqual(batches, expected_batches)
 
         # Test all files in one batch
-        batches = list(batch_files_by_size(self.test_dir, target_size=1000))
+        batches = sorted(list(batch_files_by_size(self.test_dir, target_size=1000)))
         expected_batches = [
             ["dir1/file1.txt", "dir1/file2.tiff", "dir1/sub_dir1/file3.h5", "dir1/sub_dir1/file4.ims",
              "dir1/sub_dir1/sub_sub_dir1/file5.txt", "dir1/sub_dir1/sub_sub_dir1/file6.tiff",

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest.mock import patch
+
+from aind_data_transfer.util.file_utils import collect_filepaths, batch_files_by_size
+
+
+class TestFileUtils(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_files = [
+            ('/root', ['subdir1', 'subdir2'], ['file1.txt', 'file2.tiff']),
+            ('/root/subdir1', [], ['file3.h5']),
+            ('/root/subdir2', [], ['file4.ims', 'file5.txt'])
+        ]
+
+        self.mock_file_sizes = {
+            '/root/file1.txt': 5,
+            '/root/file2.tiff': 10,
+            '/root/subdir1/file3.h5': 50,
+            '/root/subdir2/file4.ims': 40,
+            '/root/subdir2/file5.txt': 20,
+        }
+
+    def test_collect_filepaths(self):
+        with patch('os.walk') as mock_walk:
+            mock_walk.return_value = self.mock_files
+
+            # Test without any filters
+            paths = list(collect_filepaths('/root'))
+            expected_paths = [
+                '/root/file1.txt',
+                '/root/file2.tiff',
+                '/root/subdir1/file3.h5',
+                '/root/subdir2/file4.ims',
+                '/root/subdir2/file5.txt'
+            ]
+            self.assertEqual(paths, expected_paths)
+
+            # Test with include_exts filter
+            paths = list(collect_filepaths('/root', include_exts=['.tiff', '.h5']))
+            expected_paths = ['/root/file2.tiff', '/root/subdir1/file3.h5']
+            self.assertEqual(paths, expected_paths)
+
+            # Test with exclude_dirs filter
+            paths = list(collect_filepaths('/root', exclude_dirs=['subdir2']))
+            expected_paths = ['/root/file1.txt', '/root/file2.tiff', '/root/subdir1/file3.h5']
+            self.assertEqual(paths, expected_paths)
+
+            # Test non-recursive
+            paths = list(collect_filepaths('/root', recursive=False))
+            expected_paths = ['/root/file1.txt', '/root/file2.tiff']
+            self.assertEqual(paths, expected_paths)
+
+    def test_batch_files_by_size(self):
+        with patch('os.path.getsize', side_effect=lambda x: self.mock_file_sizes[x]):
+            filepaths = [
+                '/root/file1.txt',
+                '/root/file2.tiff',
+                '/root/subdir1/file3.h5',
+                '/root/subdir2/file4.ims',
+                '/root/subdir2/file5.txt',
+            ]
+
+            # Test batching by size
+            batches = list(batch_files_by_size(filepaths, target_size=10))
+            expected_batches = [['/root/file1.txt'], ['/root/file2.tiff'],
+                                ['/root/subdir1/file3.h5'], ['/root/subdir2/file4.ims'], ['/root/subdir2/file5.txt']]
+            self.assertEqual(batches, expected_batches)
+
+            # Increase target size to group files
+            batches = list(batch_files_by_size(filepaths, target_size=100))
+            expected_batches = [['/root/file1.txt', '/root/file2.tiff', '/root/subdir1/file3.h5'],
+                                ['/root/subdir2/file4.ims', '/root/subdir2/file5.txt']]
+            self.assertEqual(batches, expected_batches)
+
+            # Test with one large file exceeding the target size
+            batches = list(batch_files_by_size(filepaths, target_size=45))
+            expected_batches = [['/root/file1.txt', '/root/file2.tiff'],
+                                ['/root/subdir1/file3.h5'], ['/root/subdir2/file4.ims'], ['/root/subdir2/file5.txt']]
+            self.assertEqual(batches, expected_batches)
+
+            # Test with multiple files just fitting the target size
+            batches = list(batch_files_by_size(filepaths, target_size=60))
+            expected_batches = [['/root/file1.txt', '/root/file2.tiff'], ['/root/subdir1/file3.h5'],
+                                ['/root/subdir2/file4.ims', '/root/subdir2/file5.txt']]
+            self.assertEqual(batches, expected_batches)
+
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -95,42 +95,37 @@ class TestFileUtils(unittest.TestCase):
         self.assertEqual(result_with_size, expected_result_with_size)
 
     def test_batch_files_by_size_complex(self):
-        # Test target size of 250
-        batches = sorted(list(batch_files_by_size(self.test_dir, target_size=250)))
-        expected_batches = [
-            ["dir1/file1.txt", "dir1/file2.tiff"],
-            ["dir1/sub_dir1/file3.h5", "dir1/sub_dir1/file4.ims", "dir1/sub_dir1/sub_sub_dir1/file5.txt"],
-            ["dir1/sub_dir1/sub_sub_dir1/file6.tiff", "dir2/file7.ims"],
-            ["dir2/file8.txt", "exclude_dir/file9.h5"]
+        expected_files = [
+            "dir1/file1.txt",
+            "dir1/file2.tiff",
+            "dir1/sub_dir1/file3.h5",
+            "dir1/sub_dir1/file4.ims",
+            "dir1/sub_dir1/sub_sub_dir1/file5.txt",
+            "dir1/sub_dir1/sub_sub_dir1/file6.tiff",
+            "dir2/file7.ims",
+            "dir2/file8.txt",
+            "exclude_dir/file9.h5"
         ]
-        expected_batches = [[os.path.join(self.test_dir, path) for path in batch] for batch in expected_batches]
-        self.assertEqual(batches, expected_batches)
+        expected_files = [os.path.join(self.test_dir, path) for path in expected_files]
 
-        # Test target size of 100
-        batches = sorted(list(batch_files_by_size(self.test_dir, target_size=100)))
-        expected_batches = [
-            ["dir1/file1.txt"],
-            ["dir1/file2.tiff"],
-            ["dir1/sub_dir1/file3.h5"],
-            ["dir1/sub_dir1/file4.ims"],
-            ["dir1/sub_dir1/sub_sub_dir1/file5.txt"],
-            ["dir1/sub_dir1/sub_sub_dir1/file6.tiff"],
-            ["dir2/file7.ims"],
-            ["dir2/file8.txt"],
-            ["exclude_dir/file9.h5"]
-        ]
-        expected_batches = [[os.path.join(self.test_dir, path) for path in batch] for batch in expected_batches]
-        self.assertEqual(batches, expected_batches)
+        batches = list(batch_files_by_size(self.test_dir, target_size=250))
+        self._validate_batch_invariants(expected_files, batches, 250)
 
-        # Test all files in one batch
-        batches = sorted(list(batch_files_by_size(self.test_dir, target_size=1000)))
-        expected_batches = [
-            ["dir1/file1.txt", "dir1/file2.tiff", "dir1/sub_dir1/file3.h5", "dir1/sub_dir1/file4.ims",
-             "dir1/sub_dir1/sub_sub_dir1/file5.txt", "dir1/sub_dir1/sub_sub_dir1/file6.tiff",
-             "dir2/file7.ims", "dir2/file8.txt", "exclude_dir/file9.h5"]
-        ]
-        expected_batches = [[os.path.join(self.test_dir, path) for path in batch] for batch in expected_batches]
-        self.assertEqual(batches, expected_batches)
+        batches = list(batch_files_by_size(self.test_dir, target_size=100))
+        self._validate_batch_invariants(expected_files, batches, 100)
+
+        batches = list(batch_files_by_size(self.test_dir, target_size=1000))
+        self._validate_batch_invariants(expected_files, batches, 1000)
+
+    def _validate_batch_invariants(self, expected_files, batches, target_size):
+        all_files_in_batches = [file for batch in batches for file in batch]
+        self.assertEqual(set(all_files_in_batches), set(expected_files))  # All files are present
+
+        for batch in batches:
+            batch_size = sum(os.path.getsize(file) for file in batch)
+            self.assertTrue(len(batch) > 0)
+            if len(batch) > 1:
+                self.assertLessEqual(batch_size, target_size)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR changes how file collection works for the `s3_upload.py` script. 

Currently, the entire input directory is scanned and upload-able file paths are added to a list. The whole list is then chunked and chunks are passed to dask workers for upload. This step can take hours when there are millions of small files. 

Instead, we can batch files for upload during the directory scan. Files are accumulated into batches with size `total_bytes <= target_bytes` and each batch is submitted as a separate upload task.

`os.scandir` is used to take advantage of the cached stat information, which is discarded with `os.walk`

There were a couple breaking changes:
* `aind_data_transfer.util.file_utils.collect_filepaths` now returns a `Generator` instead of `List`
* the `batch_num` parameter in `s3_upload.py` is replaced with `batch_size`, in bytes. The default is 256MB, which appears to balance batch creation speed with worker processing speed. Using a larger batch size (512MB - 1GB) can result in idle workers if the batch creation becomes slower than upload. This parameter and the number of HPC cores will need to be adjusted depending on the workload.

I went through the whole code base and fixed all uses of these. 

**Benchmarks**
629.5GB SmarSPIM dataset was uploaded in 309s, with 4 nodes * 8 cores per node, ~2GB/s
We are now limited by how quickly the input directory can be traversed. Parallelizing the directory scan could be a future improvement.

Closes #286 