### PR TITLE
Fix writing ephys to output folder with SI 0.100.0

### DIFF
--- a/src/aind_data_transfer/writers/ephys_writers.py
+++ b/src/aind_data_transfer/writers/ephys_writers.py
@@ -66,7 +66,7 @@ class EphysWriters:
                 )
             _ = rec.save(
                 format=output_format,
-                zarr_path=zarr_path,
+                folder=zarr_path,
                 compressor=compressor,
                 **job_kwargs,
             )

--- a/tests/resources/test_metadata/processing.json
+++ b/tests/resources/test_metadata/processing.json
@@ -5,7 +5,7 @@
       "data_processes": [
          {
             "name": "Ephys preprocessing",
-            "software_version": "0.32.6",
+            "software_version": "0.32.7",
             "start_date_time": "2020-10-20T00:00:00Z",
             "end_date_time": "2020-10-20T01:00:00Z",
             "input_location": "some_input_location",


### PR DESCRIPTION
@jtyoung84 

The issue is that the new SpikeInterface version uses the `folder` kwarg (instead of the `zarr_path`).

Can you test if this fixes the output folder issue?