### PR TITLE
Fix XAmzContentSHA256Mismatch on OME-Zarr upload

### DIFF
--- a/scripts/singularity/aind_data_transfer.def
+++ b/scripts/singularity/aind_data_transfer.def
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: python:3.11-bullseye
+From: python:3.10-bullseye
 
 %files
     post_install.sh

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -86,7 +86,7 @@ def write_files(
                     'mode': _S3_RETRY_MODE,
                 }
             },
-            use_ssl=False,
+            use_ssl=True,
         )
         # Create a Zarr group on S3
         store = s3fs.S3Map(root=output, s3=s3, check=False)

--- a/tests/test_metadata_creation.py
+++ b/tests/test_metadata_creation.py
@@ -4,18 +4,18 @@ import json
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, call, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
-from aind_data_schema.core.processing import Processing
+from aind_data_schema.core.data_description import Funding, RawDataDescription
 from aind_data_schema.core.procedures import Procedures
-from aind_data_schema.core.data_description import RawDataDescription
+from aind_data_schema.core.processing import Processing
 from aind_data_schema.core.subject import Subject
-from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.modalities import Modality
+from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.process_names import ProcessName
-from aind_data_schema.core.data_description import Funding
 from requests import ConnectionError, Response
 
+from aind_data_transfer import __version__
 from aind_data_transfer.config_loader.ephys_configuration_loader import (
     EphysJobConfigurationLoader,
 )
@@ -90,7 +90,9 @@ class TestProcessingMetadata(unittest.TestCase):
         expected_processing_instance = Processing.model_validate(
             expected_processing_instance_json
         )
-
+        expected_processing_instance.processing_pipeline.data_processes[
+            0
+        ].software_version = __version__
         self.assertEqual(
             json.loads(expected_processing_instance.model_dump_json()),
             processing_metadata.model_obj,


### PR DESCRIPTION
Resolves the following error during S3 upload

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/s3fs/core.py", line 113, in _error_wrapper
    return await func(*args, **kwargs)
    ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiobotocore/client.py", line 386, in _make_api_call
    raise error_class(parsed_response, operation_name)
    ^^^^^^^^^^^^^^^^^
botocore.exceptions.ClientError: An error occurred (XAmzContentSHA256Mismatch) when calling the PutObject operation: The provided 'x-amz-content-sha256' header does not match what was computed.
```


- We first noticed this error on 2/27. `use_ssl=False` had not caused problems prior to then. Setting to `True` resolves the issue.
- Use py3.10 for singularity definition since there may be a bug in asyncio with 3.11 
```shell
Traceback (most recent call last):
  File "/allen/aind/scratch/cameron.arshadi/miniconda3/envs/adt/lib/python3.11/asyncio/selector_events.py", line 900, in _call_connection_lost
    self._protocol.connection_lost(exc)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'connection_lost'
```