### PR TITLE
Upgrade spikeinterface to fix wrong compressor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     'Sphinx'
 ]
 ephys = [
-    'spikeinterface[full]>=0.100.0',
+    'spikeinterface[full]>=0.100.3',
     'probeinterface==0.2.21',
     'wavpack-numcodecs>=0.1.3,<=0.1.5'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     'Sphinx'
 ]
 ephys = [
-    'spikeinterface[full]>=0.100.3',
+    'spikeinterface[full]>=0.100.4',
     'probeinterface==0.2.21',
     'wavpack-numcodecs>=0.1.3,<=0.1.5'
 ]

--- a/src/aind_data_transfer/writers/ephys_writers.py
+++ b/src/aind_data_transfer/writers/ephys_writers.py
@@ -69,7 +69,7 @@ class EphysWriters:
                 format=output_format,
                 folder=zarr_path,
                 compressor=compressor,
-                compressor_by_dataset=dict(times=None)
+                compressor_by_dataset=dict(times=None),
                 **job_kwargs,
             )
 

--- a/src/aind_data_transfer/writers/ephys_writers.py
+++ b/src/aind_data_transfer/writers/ephys_writers.py
@@ -64,10 +64,12 @@ class EphysWriters:
                     f" and might lead to errors. Use a shorter destination "
                     f"path."
                 )
+            # compression for times is disabled
             _ = rec.save(
                 format=output_format,
                 folder=zarr_path,
                 compressor=compressor,
+                compressor_by_dataset=dict(times=None)
                 **job_kwargs,
             )
 

--- a/tests/test_ecephys_compression.py
+++ b/tests/test_ecephys_compression.py
@@ -3,7 +3,8 @@
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from tempfile import TemporaryDirectory
+import spikeinterface.extractors as se
 
 from aind_data_transfer.transformations.ephys_compressors import (
     EcephysCompressionParameters,
@@ -18,171 +19,36 @@ BEHAVIOR_DIR = TEST_DIR / "v0.6.x_neuropixels_multiexp_multistream" / "Videos"
 class TestEcephysCompression(unittest.TestCase):
     """Tests for EcephysJob class"""
 
-    @patch("shutil.copytree")
-    @patch("shutil.ignore_patterns")
-    @patch("aind_data_transfer.transformations.ephys_compressors.memmap")
-    @patch(
-        "aind_data_transfer.readers.ephys_readers.EphysReaders."
-        "get_streams_to_clip"
-    )
-    @patch(
-        "aind_data_transfer.readers.ephys_readers.EphysReaders."
-        "get_read_blocks"
-    )
-    @patch(
-        "aind_data_transfer.transformations.ephys_compressors."
-        "EphysCompressors.get_compressor"
-    )
-    @patch(
-        "aind_data_transfer.transformations.ephys_compressors."
-        "EphysCompressors.scale_read_blocks"
-    )
-    @patch(
-        "aind_data_transfer.writers.ephys_writers.EphysWriters."
-        "compress_and_write_block"
-    )
-    @patch(
-        "aind_data_transfer.transformations.ephys_compressors."
-        "correct_np_opto_electrode_locations"
-    )
     def test_ecephys_job_with_compression(
         self,
-        mock_correct_np_opto: MagicMock,
-        mock_write_block: MagicMock,
-        mock_scale_read_blocks: MagicMock,
-        mock_get_compressor: MagicMock,
-        mock_get_read_blocks: MagicMock,
-        mock_get_streams_to_clip: MagicMock,
-        mock_memmap: MagicMock,
-        mock_ignore_patterns: MagicMock,
-        mock_copytree: MagicMock,
     ):
         """Tests ecephys job runs correctly with compression"""
-        mock_get_streams_to_clip.return_value.__iter__.return_value = [
-            {"data": [], "relative_path_name": "some_rel_path", "n_chan": 1}
-        ]
-        mock_ignore_patterns.side_effect = [
-            ["*.dat"],
-            ["*.dat", str(BEHAVIOR_DIR / "*")],
-        ]
-        mock_get_compressor.return_value = "Mocked Compressor"
-        mock_get_read_blocks.return_value = {
-            "recording": "mocked recording",
-            "experiment_name": "mocked exp name",
-            "stream_name": "mocked stream name",
-        }
-        mock_scale_read_blocks.return_value = {
-            "scaled_recording": "mocked scale rec",
-            "experiment_name": "mocked exp name",
-            "stream_name": "mocked stream name",
-        }
 
-        ecephys_configs = EcephysCompressionParameters(source=DATA_DIR)
-        ecephys_compressor = EphysCompressors(
-            job_configs=ecephys_configs, behavior_dir=BEHAVIOR_DIR
-        )
-        ecephys_compressor.compress_raw_data(temp_dir=Path("some_path"))
-        ecephys_compressor.compress_raw_data(temp_dir=Path("some_path"))
-        mock_correct_np_opto.assert_has_calls([call(DATA_DIR), call(DATA_DIR)])
-        mock_copytree.assert_has_calls(
-            [
-                call(
-                    DATA_DIR,
-                    Path("some_path/ecephys_clipped"),
-                    ignore=["*.dat"],
-                ),
-                call(
-                    DATA_DIR,
-                    Path("some_path/ecephys_clipped"),
-                    ignore=["*.dat", str(BEHAVIOR_DIR / "*")],
-                ),
-            ]
-        )
-        mock_get_streams_to_clip.assert_has_calls(
-            [
-                call("openephys", DATA_DIR),
-                call().__iter__(),
-                call("openephys", DATA_DIR),
-                call().__iter__(),
-            ]
-        )
-        mock_memmap.assert_has_calls(
-            [
-                call(
-                    Path("some_path/ecephys_clipped/some_rel_path"),
-                    dtype="int16",
-                    shape=(100, 1),
-                    order="C",
-                    mode="w+",
-                ),
-                call().__setitem__(slice(None, None, None), []),
-                call(
-                    Path("some_path/ecephys_clipped/some_rel_path"),
-                    dtype="int16",
-                    shape=(100, 1),
-                    order="C",
-                    mode="w+",
-                ),
-                call().__setitem__(slice(None, None, None), []),
-            ]
-        )
-        mock_get_read_blocks.assert_has_calls(
-            [call("openephys", DATA_DIR), call("openephys", DATA_DIR)]
-        )
+        with TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            ecephys_configs = EcephysCompressionParameters(source=DATA_DIR)
+            ecephys_compressor = EphysCompressors(
+                job_configs=ecephys_configs, behavior_dir=BEHAVIOR_DIR
+            )
+            ecephys_compressor.compress_raw_data(
+                temp_dir=tmp_dir / "some_path"
+            )
 
-        mock_get_compressor.assert_has_calls(
-            [call("wavpack", level=3), call("wavpack", level=3)]
-        )
-        mock_scale_read_blocks.assert_has_calls(
-            [
-                call(
-                    read_blocks={
-                        "recording": "mocked recording",
-                        "experiment_name": "mocked exp name",
-                        "stream_name": "mocked stream name",
-                    },
-                    num_chunks_per_segment=100,
-                    chunk_size=10000,
-                ),
-                call(
-                    read_blocks={
-                        "recording": "mocked recording",
-                        "experiment_name": "mocked exp name",
-                        "stream_name": "mocked stream name",
-                    },
-                    num_chunks_per_segment=100,
-                    chunk_size=10000,
-                ),
-            ]
-        )
-        mock_write_block.assert_has_calls(
-            [
-                call(
-                    read_blocks={
-                        "scaled_recording": "mocked scale rec",
-                        "experiment_name": "mocked exp name",
-                        "stream_name": "mocked stream name",
-                    },
-                    compressor="Mocked Compressor",
-                    output_dir=Path("some_path/ecephys_compressed"),
-                    max_windows_filename_len=150,
-                    output_format="zarr",
-                    job_kwargs={"n_jobs": -1},
-                ),
-                call(
-                    read_blocks={
-                        "scaled_recording": "mocked scale rec",
-                        "experiment_name": "mocked exp name",
-                        "stream_name": "mocked stream name",
-                    },
-                    compressor="Mocked Compressor",
-                    output_dir=Path("some_path/ecephys_compressed"),
-                    max_windows_filename_len=150,
-                    output_format="zarr",
-                    job_kwargs={"n_jobs": -1},
-                ),
-            ]
-        )
+            # Check if the compressed data is written
+            assert (tmp_dir / "some_path" / "ecephys_clipped").is_dir()
+            assert (tmp_dir / "some_path" / "ecephys_compressed").is_dir()
+            # Check that all streams and blocks are compressed
+            num_blocks = se.get_neo_num_blocks("openephys", DATA_DIR)
+            stream_names, _ = se.get_neo_streams("openephys", DATA_DIR)
+            for stream_name in stream_names:
+                written_zarr_folders_for_stream = [
+                    p
+                    for p in (
+                        tmp_dir / "some_path" / "ecephys_compressed"
+                    ).iterdir()
+                    if stream_name in p.name
+                ]
+                assert len(written_zarr_folders_for_stream) == num_blocks
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@jtyoung84 turns out it was a spikeinterface bug (https://github.com/SpikeInterface/spikeinterface/pull/2639) that prevented the correct propagation of the compressor to zarr.

Made a patch release and updated the requirements