### PR TITLE
Hotfix: incorrect OME-Zarr translation metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ imaging = [
     'bokeh!=3.0.*,>=2.4.2',
     'gcsfs==2024.3.1',
     'xarray-multiscale==2.1.0',
+    'xarray==2024.05.0',
     'parameterized==0.9.0',
     'ome-zarr==0.8.3',
     'chardet==5.1.0',

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -11,7 +11,10 @@ from numpy.typing import NDArray
 from ome_zarr.format import CurrentFormat
 from ome_zarr.writer import write_multiscales_metadata
 import xarray as xr
-from xarray_multiscale.multiscale import downscale_coords, multiscale
+from xarray_multiscale.multiscale import (
+    multiscale,
+    downscale
+)
 from xarray_multiscale.reducers import windowed_mean, WindowedReducer
 
 from aind_data_transfer.transformations.deinterleave import (
@@ -996,19 +999,19 @@ def _downscale_origin(
     new_origins : list of list of float
        A list of new origin coordinates for each downscaled level.
     """
-    z_coords = origin[0] + voxel_size[0] * np.arange(arr.shape[2])
-    y_coords = origin[1] + voxel_size[1] * np.arange(arr.shape[3])
-    x_coords = origin[2] + voxel_size[2] * np.arange(arr.shape[4])
+    arr = arr.squeeze()
+    z_coords = origin[0] + voxel_size[0] * np.arange(arr.shape[0])
+    y_coords = origin[1] + voxel_size[1] * np.arange(arr.shape[1])
+    x_coords = origin[2] + voxel_size[2] * np.arange(arr.shape[2])
     coords = xr.Coordinates({'z': z_coords, 'y': y_coords, 'x': x_coords})
-    ds = xr.Dataset(coords=coords)
+    ds = xr.DataArray(arr, coords=coords)
     new_origins = [list(origin)]
     for i in range(n_levels - 1):
-        new_coords = downscale_coords(ds, scale_factors)
+        ds = downscale(ds, windowed_mean, scale_factors)
         new_origins.append(
-            [float(new_coords['z'][0]), float(new_coords['y'][0]),
-             float(new_coords['x'][0])]
+            [float(ds.coords['z'][0]), float(ds.coords['y'][0]),
+             float(ds.coords['x'][0])]
         )
-        ds = xr.Dataset(coords=new_coords)
     return new_origins
 
 

--- a/src/aind_data_transfer/transformations/ome_zarr.py
+++ b/src/aind_data_transfer/transformations/ome_zarr.py
@@ -2,7 +2,7 @@ import fnmatch
 import logging
 import time
 from pathlib import Path
-from typing import List, Optional, Dict, cast
+from typing import List, Optional, Dict, cast, Any
 
 import s3fs
 import zarr
@@ -10,7 +10,8 @@ from numcodecs.abc import Codec
 from numpy.typing import NDArray
 from ome_zarr.format import CurrentFormat
 from ome_zarr.writer import write_multiscales_metadata
-from xarray_multiscale import multiscale
+import xarray as xr
+from xarray_multiscale.multiscale import downscale_coords, multiscale
 from xarray_multiscale.reducers import windowed_mean, WindowedReducer
 
 from aind_data_transfer.transformations.deinterleave import (
@@ -697,7 +698,7 @@ def _compute_scales(
     pixelsizes: Tuple[float, float, float],
     chunks: Tuple[int, int, int, int, int],
     data_shape: Tuple[int, int, int, int, int],
-    translation: Optional[List[float]] = None,
+    translations: Optional[List[List[float]]] = None,
 ) -> Tuple[List, List]:
     """Generate the list of coordinate transformations and associated chunk options.
 
@@ -708,7 +709,7 @@ def _compute_scales(
     pixelsizes: a list of pixel sizes in each spatial dimension (Z, Y, X)
     chunks: a 5D tuple of integers with size of each chunk dimension (T, C, Z, Y, X)
     data_shape: a 5D tuple of the full resolution image's shape
-    translation: a 5 element list specifying the offset in physical units in each dimension
+    translations: a list of 3 element lists specifying the offset in physical units in Z, Y, X
 
     Returns
     -------
@@ -729,9 +730,9 @@ def _compute_scales(
             }
         ]
     ]
-    if translation is not None:
+    if translations is not None:
         transforms[0].append(
-            {"type": "translation", "translation": translation}
+            {"type": "translation", "translation": [0, 0, *translations[0]]}
         )
     chunk_sizes = []
     lastz = data_shape[2]
@@ -765,9 +766,9 @@ def _compute_scales(
                     }
                 ]
             )
-            if translation is not None:
+            if translations is not None:
                 transforms[-1].append(
-                    {"type": "translation", "translation": translation}
+                    {"type": "translation", "translation": [0, 0, *translations[i+1]]}
                 )
             lastz = int(math.ceil(lastz / scale_factor[0]))
             lasty = int(math.ceil(lasty / scale_factor[1]))
@@ -966,6 +967,51 @@ def _get_first_mipmap_level(
     return ensure_array_5d(pyramid[1])
 
 
+def _downscale_origin(
+    arr: Any,
+    origin: List[float],
+    voxel_size: List[float],
+    scale_factors: List[int],
+    n_levels: int
+):
+    """
+    Calculate new origins for downscaled coordinate grids.
+
+    Parameters
+    ----------
+    arr : Any
+       Input 5D array representing the data volume.
+    origin : list or tuple of float
+       The initial origin coordinates (z, y, x) of the array.
+    voxel_size : list or tuple of float
+       The size of each voxel along the (z, y, x) dimensions.
+    scale_factors : list or tuple of float
+       The factors by which to downscale the coordinates along each axis
+       (z, y, x).
+    n_levels : int
+       The number of downscaling levels to calculate.
+
+    Returns
+    -------
+    new_origins : list of list of float
+       A list of new origin coordinates for each downscaled level.
+    """
+    z_coords = origin[0] + voxel_size[0] * np.arange(arr.shape[2])
+    y_coords = origin[1] + voxel_size[1] * np.arange(arr.shape[3])
+    x_coords = origin[2] + voxel_size[2] * np.arange(arr.shape[4])
+    coords = xr.Coordinates({'z': z_coords, 'y': y_coords, 'x': x_coords})
+    ds = xr.Dataset(coords=coords)
+    new_origins = [list(origin)]
+    for i in range(n_levels - 1):
+        new_coords = downscale_coords(ds, scale_factors)
+        new_origins.append(
+            [float(new_coords['z'][0]), float(new_coords['y'][0]),
+             float(new_coords['x'][0])]
+        )
+        ds = xr.Dataset(coords=new_coords)
+    return new_origins
+
+
 def write_ome_ngff_metadata(
     group: zarr.Group,
     arr: da.Array,
@@ -1006,6 +1052,16 @@ def write_ome_ngff_metadata(
     )
     group.attrs["omero"] = ome_json
     axes_5d = _get_axes_5d()
+
+    if origin is not None:
+        origin = _downscale_origin(
+            arr,
+            origin[-3:],
+            voxel_size[-3:],
+            scale_factors[-3:],
+            n_lvls
+        )
+
     coordinate_transformations, chunk_opts = _compute_scales(
         n_lvls, scale_factors, voxel_size, arr.chunksize, arr.shape, origin
     )

--- a/tests/test_ome_zarr.py
+++ b/tests/test_ome_zarr.py
@@ -8,14 +8,14 @@ import h5py
 import numpy as np
 import tifffile
 import zarr
-from distributed import Client
-from parameterized import parameterized
-
 from aind_data_transfer.transformations.ome_zarr import (
     write_files,
     write_folder,
+    _downscale_origin
 )
 from aind_data_transfer.util.io_utils import ImarisReader
+from distributed import Client
+from parameterized import parameterized
 
 
 def _write_test_tiffs(folder, n=4, shape=(64, 128, 128)):
@@ -34,13 +34,13 @@ def _write_test_h5(folder, n=4, shape=(64, 128, 128)):
             # Write origin metadata
             dataset_info = f.create_group("DataSetInfo/Image")
             dataset_info.attrs["ExtMin0"] = np.array(
-                ["1", "0", "0"], dtype="S"
+                ["3", "0", "0"], dtype="S"
             )
             dataset_info.attrs["ExtMin1"] = np.array(
                 ["2", "0", "0"], dtype="S"
             )
             dataset_info.attrs["ExtMin2"] = np.array(
-                ["3", "0", "0"], dtype="S"
+                ["1", "0", "0"], dtype="S"
             )
             dataset_info.attrs["X"] = np.array(list(str(shape[2])), dtype="S")
             dataset_info.attrs["Y"] = np.array(list(str(shape[1])), dtype="S")
@@ -76,9 +76,9 @@ class TestOmeZarr(unittest.TestCase):
                 expected_shape_at_lvl = (
                     1,
                     1,
-                    int(math.ceil(full_shape[2] / (scale_factor**lvl))),
-                    int(math.ceil(full_shape[3] / (scale_factor**lvl))),
-                    int(math.ceil(full_shape[4] / (scale_factor**lvl))),
+                    int(math.ceil(full_shape[2] / (scale_factor ** lvl))),
+                    int(math.ceil(full_shape[3] / (scale_factor ** lvl))),
+                    int(math.ceil(full_shape[4] / (scale_factor ** lvl))),
                 )
                 self.assertEqual(expected_shape_at_lvl, a.shape)
                 self.assertTrue(a.nbytes_stored > 0)
@@ -138,6 +138,13 @@ class TestOmeZarr(unittest.TestCase):
                 expected_axes_metadata, attrs["multiscales"][0]["axes"]
             )
 
+            expected_translations = [[100, 200, 300], [100.5, 200.5, 300.5],
+                                     [101.5, 201.5, 301.5],
+                                     [103.5, 203.5, 303.5],
+                                     [107.5, 207.5, 307.5],
+                                     [115.5, 215.5, 315.5],
+                                     [131.5, 231.5, 331.5]]
+
             datasets_metadata = attrs["multiscales"][0]["datasets"]
             for i, ds_metadata in enumerate(datasets_metadata):
                 expected_transform = {
@@ -146,9 +153,9 @@ class TestOmeZarr(unittest.TestCase):
                             "scale": [
                                 1.0,
                                 1.0,
-                                voxel_size[0] * (scale_factor**i),
-                                voxel_size[1] * (scale_factor**i),
-                                voxel_size[2] * (scale_factor**i),
+                                voxel_size[0] * (scale_factor ** i),
+                                voxel_size[1] * (scale_factor ** i),
+                                voxel_size[2] * (scale_factor ** i),
                             ],
                             "type": "scale",
                         }
@@ -158,7 +165,7 @@ class TestOmeZarr(unittest.TestCase):
                 if has_translation:
                     expected_transform["coordinateTransformations"].append(
                         {
-                            "translation": [0, 0, 300.0, 200.0, 100.0],
+                            "translation": [0, 0, *expected_translations[i]],
                             "type": "translation",
                         }
                     )
@@ -255,6 +262,25 @@ class TestOmeZarr(unittest.TestCase):
         self._check_zarr_attributes(
             z, voxel_size, scale_factor, has_translation=(file_type == "h5")
         )
+
+    def test_downscale_origin(self):
+        arr = np.ones((1, 1, 64, 128, 128), dtype=np.uint16)
+        translation = (100, 200, 300)
+        scale = (1.0, 1.0, 1.0)
+        scale_factors = (2, 2, 2)
+        n_levels = 7
+        expected_origins = [[100, 200, 300], [100.5, 200.5, 300.5],
+                            [101.5, 201.5, 301.5], [103.5, 203.5, 303.5],
+                            [107.5, 207.5, 307.5], [115.5, 215.5, 315.5],
+                            [131.5, 231.5, 331.5]]
+        test_origins = _downscale_origin(
+            arr,
+            translation,
+            scale,
+            scale_factors,
+            n_levels
+        )
+        self.assertEqual(expected_origins, test_origins)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #342 

Neuroglancer [link](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B7.480000148631623e-7%2C%22m%22%5D%2C%22y%22:%5B7.479999743009398e-7%2C%22m%22%5D%2C%22z%22:%5B0.000001%2C%22m%22%5D%2C%22t%22:%5B0.001%2C%22s%22%5D%7D%2C%22position%22:%5B-26688.111328125%2C-11572.4228515625%2C-10220.5%2C0%5D%2C%22crossSectionScale%22:148.41315910257669%2C%22projectionScale%22:65536%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%5B%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0000_y_0000_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0000_y_0001_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0000_y_0002_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0001_y_0000_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0001_y_0001_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0001_y_0002_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0002_y_0000_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0002_y_0001_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0002_y_0002_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0003_y_0000_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0003_y_0001_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0003_y_0002_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0004_y_0000_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0004_y_0001_z_0000_ch_488.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0004_y_0002_z_0000_ch_488.zarr%22%5D%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22opacity%22:1%2C%22shader%22:%22#uicontrol%20vec3%20color%20color%28default=%5C%22#59d5f8%5C%22%29%5Cn#uicontrol%20invlerp%20normalized%5Cnvoid%20main%28%29%20%7B%5CnemitRGB%28color%20%2A%20normalized%28%29%29%3B%5Cn%7D%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B30%2C100%5D%7D%7D%2C%22name%22:%22CH_488%22%2C%22visible%22:false%7D%2C%7B%22type%22:%22image%22%2C%22source%22:%5B%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0000_y_0000_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0000_y_0001_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0000_y_0002_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0001_y_0000_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0001_y_0001_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0001_y_0002_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0002_y_0000_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0002_y_0001_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0002_y_0002_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0003_y_0000_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0003_y_0001_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0003_y_0002_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0004_y_0000_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0004_y_0001_z_0000_ch_561.zarr%22%2C%22zarr://s3://aind-open-data/exaSPIM_706434_2024-05-21_12-56-07/SPIM.ome.zarr/tile_x_0004_y_0002_z_0000_ch_561.zarr%22%5D%2C%22localDimensions%22:%7B%22c%27%22:%5B1%2C%22%22%5D%7D%2C%22localPosition%22:%5B0%5D%2C%22tab%22:%22rendering%22%2C%22shader%22:%22#uicontrol%20vec3%20color%20color%28default=%5C%22#bbfb01%5C%22%29%5Cn#uicontrol%20invlerp%20normalized%5Cnvoid%20main%28%29%20%7B%5CnemitRGB%28color%20%2A%20normalized%28%29%29%3B%5Cn%7D%22%2C%22shaderControls%22:%7B%22normalized%22:%7B%22range%22:%5B2500%2C3563%5D%7D%7D%2C%22name%22:%22CH_561%22%7D%5D%2C%22showAxisLines%22:false%2C%22showScaleBar%22:false%2C%22selectedLayer%22:%7B%22visible%22:true%2C%22layer%22:%22CH_561%22%7D%2C%22layout%22:%224panel%22%7D) of corrected dataset 